### PR TITLE
Add Work page, refresh About content, and remove WIP labels from nav

### DIFF
--- a/src/components/AboutHero.html
+++ b/src/components/AboutHero.html
@@ -1,19 +1,19 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
-  <section class="grid gap-10 text-center md:grid-cols-[1.1fr,0.9fr] md:text-left lg:px-[2.5rem]">
-    <div class="flex flex-col gap-6 max-w-4xl mx-auto">
-      <div class="space-y-3">
-        <p class="text-sm font-semibold uppercase tracking-[0.4em] text-[#2f6bff]">About</p>
-        <h1 class="text-[42px] font-semibold tracking-tight text-[#0b0f1a] md:text-7xl">
-          Building with clarity, momentum, and care.
-        </h1>
-      </div>
-      <p class="text-lg md:text-[22px] md:leading-[36px] text-[#3d4663]">
+  <section class="grid gap-12 md:grid-cols-[1.05fr,0.95fr] lg:px-[2.5rem]">
+    <div class="flex flex-col gap-6">
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">
+        About
+      </p>
+      <h1 class="text-[42px] font-semibold tracking-tight text-[#0c111f] md:text-7xl">
+        Building modern web products with calm, precise execution.
+      </h1>
+      <p class="text-lg md:text-[22px] md:leading-[36px] text-[#4a5162]">
         Certified expert full-stack software engineer with 10+ years of experience building highly performant, accessible web experiences with JavaScript, TypeScript, and modern frameworks. I lead teams, mentor developers, and love pushing the boundaries of what the web can do.
       </p>
       <div class="flex flex-wrap items-center gap-4">
         <a
           href="https://www.linkedin.com/in/jdrechslerus"
-          class="inline-flex items-center gap-2 rounded-full bg-[#0b0f1a] px-5 py-2 text-white text-sm font-semibold tracking-wide shadow-lg shadow-black/15 transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full bg-[#0c111f] px-5 py-2 text-white text-sm font-semibold tracking-wide shadow-[0_12px_30px_rgba(12,17,31,0.2)] transition hover:-translate-y-0.5"
         >
           Connect on LinkedIn
           <svg
@@ -50,16 +50,17 @@
         </a>
         <a
           href="/work"
-          class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-5 py-2 text-sm font-semibold text-[#0b0f1a] shadow-sm transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-5 py-2 text-sm font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5"
         >
           Explore Work
         </a>
       </div>
     </div>
     <div class="relative">
-      <div class="absolute -inset-4 rounded-[2.5rem] bg-gradient-to-tr from-[#2f6bff]/20 via-white/10 to-[#f59e0b]/20 blur-2xl"></div>
+      <div class="absolute inset-4 rounded-[2.5rem] border border-white/60"></div>
+      <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-tr from-[#2662ff]/20 via-white/10 to-[#ff8c78]/20 blur-2xl"></div>
       <img
-        class="relative h-[420px] w-full object-cover rounded-[2.5rem] border border-white/60 shadow-[0_20px_60px_rgba(15,23,42,0.2)]"
+        class="relative h-[420px] w-full rounded-[2.5rem] border border-white/70 object-cover shadow-[0_30px_70px_rgba(15,23,42,0.18)]"
         src="/assets/profile.jpg"
         alt="Myself in Daytona Beach, Florida"
       />

--- a/src/components/AboutHero.html
+++ b/src/components/AboutHero.html
@@ -1,19 +1,19 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
-  <section class="grid gap-x-5 gap-y-5 text-center md:text-left justify-center justify-items-center items-center gap-y-[2rem] gap-x-[3.75rem] lg:px-[2.5rem]">
-    <div class="flex flex-col md:gap-5 max-w-4xl mx-auto">
-      <div class="space-y-2">
-        <p class="text-accent font-medium tracking-wide">FULL-STACK SOFTWARE ENGINEER</p>
-        <h1 class="text-[42px] text-[#090b11] font-bold tracking-wider leading-[1.1] md:text-7xl bg-gradient-to-r from-[#090b11] via-accent to-[#090b11] bg-clip-text text-transparent">
-          About Me
+  <section class="grid gap-10 text-center md:grid-cols-[1.1fr,0.9fr] md:text-left lg:px-[2.5rem]">
+    <div class="flex flex-col gap-6 max-w-4xl mx-auto">
+      <div class="space-y-3">
+        <p class="text-sm font-semibold uppercase tracking-[0.4em] text-[#2f6bff]">About</p>
+        <h1 class="text-[42px] font-semibold tracking-tight text-[#0b0f1a] md:text-7xl">
+          Building with clarity, momentum, and care.
         </h1>
       </div>
-      <p class="text-xl mx-auto md:mx-0 text-[#3d4663] !leading-[39px] md:text-[26px] mt-6">
+      <p class="text-lg md:text-[22px] md:leading-[36px] text-[#3d4663]">
         Certified expert full-stack software engineer with 10+ years of experience building highly performant, accessible web experiences with JavaScript, TypeScript, and modern frameworks. I lead teams, mentor developers, and love pushing the boundaries of what the web can do.
       </p>
-      <div class="mt-4 flex flex-wrap items-center gap-4">
+      <div class="flex flex-wrap items-center gap-4">
         <a
           href="https://www.linkedin.com/in/jdrechslerus"
-          class="inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2 text-white text-sm font-semibold tracking-wide hover:opacity-90 transition-opacity"
+          class="inline-flex items-center gap-2 rounded-full bg-[#0b0f1a] px-5 py-2 text-white text-sm font-semibold tracking-wide shadow-lg shadow-black/15 transition hover:-translate-y-0.5"
         >
           Connect on LinkedIn
           <svg
@@ -48,15 +48,21 @@
             </g>
           </svg>
         </a>
+        <a
+          href="/work"
+          class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-5 py-2 text-sm font-semibold text-[#0b0f1a] shadow-sm transition hover:-translate-y-0.5"
+        >
+          Explore Work
+        </a>
       </div>
     </div>
-    <div class="relative w-full max-w-2xl group transition-all duration-300">
+    <div class="relative">
+      <div class="absolute -inset-4 rounded-[2.5rem] bg-gradient-to-tr from-[#2f6bff]/20 via-white/10 to-[#f59e0b]/20 blur-2xl"></div>
       <img
-        class="w-full h-[420px] object-cover rounded-[2rem] shadow-xl transition-transform duration-300 group-hover:scale-[1.02]"
+        class="relative h-[420px] w-full object-cover rounded-[2.5rem] border border-white/60 shadow-[0_20px_60px_rgba(15,23,42,0.2)]"
         src="/assets/profile.jpg"
         alt="Myself in Daytona Beach, Florida"
       />
-      <div class="absolute inset-0 rounded-[2rem] bg-gradient-to-t from-black/40 via-black/20 to-transparent"></div>
     </div>
   </section>
 </div>

--- a/src/components/AboutHero.html
+++ b/src/components/AboutHero.html
@@ -10,6 +10,45 @@
       <p class="text-xl mx-auto md:mx-0 text-[#3d4663] !leading-[39px] md:text-[26px] mt-6">
         Certified expert full-stack software engineer with 10+ years of experience building highly performant, accessible web experiences with JavaScript, TypeScript, and modern frameworks. I lead teams, mentor developers, and love pushing the boundaries of what the web can do.
       </p>
+      <div class="mt-4 flex flex-wrap items-center gap-4">
+        <a
+          href="https://www.linkedin.com/in/jdrechslerus"
+          class="inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2 text-white text-sm font-semibold tracking-wide hover:opacity-90 transition-opacity"
+        >
+          Connect on LinkedIn
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 256 256"
+            aria-hidden="true"
+            stroke="currentcolor"
+            fill="currentcolor"
+          >
+            <g>
+              <rect
+                width="184"
+                height="184"
+                x="36"
+                y="36"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+                rx="8"
+              ></rect>
+              <path
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+                d="M120 112v64m-32-64v64m32-36a28 28 0 0 1 56 0v36"
+              ></path>
+              <circle stroke="none" cx="88" cy="80" r="12"></circle>
+            </g>
+          </svg>
+        </a>
+      </div>
     </div>
     <div class="relative w-full max-w-2xl group transition-all duration-300">
       <img

--- a/src/components/AboutHero.html
+++ b/src/components/AboutHero.html
@@ -1,19 +1,19 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
   <section class="grid gap-12 md:grid-cols-[1.05fr,0.95fr] lg:px-[2.5rem]">
     <div class="flex flex-col gap-6">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">
         About
       </p>
-      <h1 class="text-[42px] font-semibold tracking-tight text-[#0c111f] md:text-7xl">
+      <h1 class="text-[42px] font-semibold tracking-tight text-[#2f3447] md:text-7xl">
         Building modern web products with calm, precise execution.
       </h1>
-      <p class="text-lg md:text-[22px] md:leading-[36px] text-[#4a5162]">
+      <p class="text-lg md:text-[22px] md:leading-[36px] text-[#5f6577]">
         Certified expert full-stack software engineer with 10+ years of experience building highly performant, accessible web experiences with JavaScript, TypeScript, and modern frameworks. I lead teams, mentor developers, and love pushing the boundaries of what the web can do.
       </p>
       <div class="flex flex-wrap items-center gap-4">
         <a
           href="https://www.linkedin.com/in/jdrechslerus"
-          class="inline-flex items-center gap-2 rounded-full bg-[#0c111f] px-5 py-2 text-white text-sm font-semibold tracking-wide shadow-[0_12px_30px_rgba(12,17,31,0.2)] transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#f08a5d] to-[#f7b267] px-5 py-2 text-white text-sm font-semibold tracking-wide shadow-[0_12px_30px_rgba(240,138,93,0.3)] transition hover:-translate-y-0.5"
         >
           Connect on LinkedIn
           <svg
@@ -50,17 +50,17 @@
         </a>
         <a
           href="/work"
-          class="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-5 py-2 text-sm font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/90 px-5 py-2 text-sm font-semibold text-[#2f3447] shadow-sm transition hover:-translate-y-0.5"
         >
           Explore Work
         </a>
       </div>
     </div>
     <div class="relative">
-      <div class="absolute inset-4 rounded-[2.5rem] border border-white/60"></div>
-      <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-tr from-[#2662ff]/20 via-white/10 to-[#ff8c78]/20 blur-2xl"></div>
+      <div class="absolute inset-4 rounded-[2.5rem] border border-white/70"></div>
+      <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-tr from-[#f08a5d]/25 via-white/20 to-[#f7b267]/25 blur-2xl"></div>
       <img
-        class="relative h-[420px] w-full rounded-[2.5rem] border border-white/70 object-cover shadow-[0_30px_70px_rgba(15,23,42,0.18)]"
+        class="relative h-[420px] w-full rounded-[2.5rem] border border-white/80 object-cover shadow-[0_30px_70px_rgba(45,42,36,0.18)]"
         src="/assets/profile.jpg"
         alt="Myself in Daytona Beach, Florida"
       />

--- a/src/components/AboutHero.html
+++ b/src/components/AboutHero.html
@@ -8,7 +8,7 @@
         </h1>
       </div>
       <p class="text-xl mx-auto md:mx-0 text-[#3d4663] !leading-[39px] md:text-[26px] mt-6">
-        Thanks for stopping by. I'm a Full-Stack Software Engineer with over 8 years of experience crafting exceptional digital experiences. My focus is on delivering high-performance, accessible, and user-centric solutions.
+        Certified expert full-stack software engineer with 10+ years of experience building highly performant, accessible web experiences with JavaScript, TypeScript, and modern frameworks. I lead teams, mentor developers, and love pushing the boundaries of what the web can do.
       </p>
     </div>
     <div class="relative w-full max-w-2xl group transition-all duration-300">

--- a/src/components/AboutMain.html
+++ b/src/components/AboutMain.html
@@ -1,8 +1,8 @@
-<section class="flex flex-col gap-12 w-full mx-auto px-[1.5rem] max-w-[83rem] text-lg text-[#4a5162] md:text-xl">
-  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
+<section class="flex flex-col gap-12 w-full mx-auto px-[1.5rem] max-w-[83rem] text-lg text-[#5f6577] md:text-xl">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/80 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Current Focus</p>
-      <h2 class="text-3xl font-semibold text-[#0c111f]">Developer Experience</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Current Focus</p>
+      <h2 class="text-3xl font-semibold text-[#2f3447]">Developer Experience</h2>
     </div>
     <div class="space-y-4">
       <p>
@@ -11,56 +11,56 @@
         recompilation delays and allows teams to stay in flow while building modern web apps.
       </p>
       <div class="grid gap-4 md:grid-cols-2">
-        <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
-          <p class="font-semibold text-[#0c111f]">Focus Areas</p>
-          <p class="mt-2 text-[#4a5162]">Component-level hot reload, state preservation, and zero-distraction feedback loops.</p>
+        <div class="rounded-2xl border border-white/70 bg-white/90 p-5">
+          <p class="font-semibold text-[#2f3447]">Focus Areas</p>
+          <p class="mt-2 text-[#5f6577]">Component-level hot reload, state preservation, and zero-distraction feedback loops.</p>
         </div>
-        <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
-          <p class="font-semibold text-[#0c111f]">Why It Matters</p>
-          <p class="mt-2 text-[#4a5162]">Faster iteration cycles, improved team velocity, and a more enjoyable development process.</p>
+        <div class="rounded-2xl border border-white/70 bg-white/90 p-5">
+          <p class="font-semibold text-[#2f3447]">Why It Matters</p>
+          <p class="mt-2 text-[#5f6577]">Faster iteration cycles, improved team velocity, and a more enjoyable development process.</p>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/80 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Experience</p>
-      <h2 class="text-3xl font-semibold text-[#0c111f]">Career Timeline</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Experience</p>
+      <h2 class="text-3xl font-semibold text-[#2f3447]">Career Timeline</h2>
     </div>
     <div class="space-y-6">
-      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/90 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#0c111f]">Senior Frontend Engineer · YAZIO</h3>
+          <h3 class="font-semibold text-xl text-[#2f3447]">Senior Frontend Engineer · YAZIO</h3>
           <span class="text-sm text-gray-500">Mar 2024 — Present · Remote</span>
         </div>
-        <p class="mt-3 text-[#4a5162]">Leading frontend delivery for high-scale consumer web experiences.</p>
+        <p class="mt-3 text-[#5f6577]">Leading frontend delivery for high-scale consumer web experiences.</p>
       </div>
-      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/90 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#0c111f]">Lead Software Engineer · MaibornWolff</h3>
+          <h3 class="font-semibold text-xl text-[#2f3447]">Lead Software Engineer · MaibornWolff</h3>
           <span class="text-sm text-gray-500">Feb 2024 — Mar 2024 · Valencia</span>
         </div>
-        <p class="mt-3 text-[#4a5162]">Short-term leadership role focused on delivery excellence and team enablement.</p>
+        <p class="mt-3 text-[#5f6577]">Short-term leadership role focused on delivery excellence and team enablement.</p>
       </div>
-      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/90 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#0c111f]">Full-Stack Software Engineer · BMW Group</h3>
+          <h3 class="font-semibold text-xl text-[#2f3447]">Full-Stack Software Engineer · BMW Group</h3>
           <span class="text-sm text-gray-500">Jan 2020 — Oct 2023 · Greenville, SC</span>
         </div>
-        <ul class="mt-3 space-y-2 text-[#4a5162] list-disc list-inside">
+        <ul class="mt-3 space-y-2 text-[#5f6577] list-disc list-inside">
           <li>Led Gatsby + React marketing site build from scratch.</li>
           <li>Built a TypeScript-driven testing pipeline (TestCafe, Jenkins, Jira reporters).</li>
           <li>Improved Lighthouse scores to 97–100 across performance, accessibility, best practices, and SEO.</li>
           <li>Delivered Angular 10 smart charging platform and Angular 12 + NestJS smart ticket platform.</li>
         </ul>
       </div>
-      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/90 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#0c111f]">Software Developer · Arvato Systems</h3>
+          <h3 class="font-semibold text-xl text-[#2f3447]">Software Developer · Arvato Systems</h3>
           <span class="text-sm text-gray-500">Sep 2012 — Jan 2020 · Leipzig/Greenville</span>
         </div>
-        <ul class="mt-3 space-y-2 text-[#4a5162] list-disc list-inside">
+        <ul class="mt-3 space-y-2 text-[#5f6577] list-disc list-inside">
           <li>Built modern web platforms and mobile-first experiences for global enterprises.</li>
           <li>Improved performance by reducing start page payloads and load times on 3G networks.</li>
           <li>Led test management for a 20+ person team on a major retail project.</li>
@@ -69,30 +69,30 @@
     </div>
   </div>
 
-  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/80 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Recognition</p>
-      <h2 class="text-3xl font-semibold text-[#0c111f]">Honors & Languages</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Recognition</p>
+      <h2 class="text-3xl font-semibold text-[#2f3447]">Honors & Languages</h2>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
-      <div class="rounded-2xl border border-white/70 bg-gradient-to-br from-white via-white/70 to-white/40 p-6 shadow-sm">
+      <div class="rounded-2xl border border-white/70 bg-gradient-to-br from-white via-white/80 to-white/50 p-6 shadow-sm">
         <div class="flex items-center justify-between gap-4">
-          <h3 class="font-semibold text-xl text-[#0c111f]">Honors & Awards</h3>
-          <span class="inline-flex items-center gap-2 rounded-full bg-[#2662ff]/10 text-[#2662ff] px-3 py-1 text-xs font-semibold tracking-wide">
+          <h3 class="font-semibold text-xl text-[#2f3447]">Honors & Awards</h3>
+          <span class="inline-flex items-center gap-2 rounded-full bg-[#f7b267]/20 text-[#d16d45] px-3 py-1 text-xs font-semibold tracking-wide">
             Top 2% • Duolingo
           </span>
         </div>
-        <p class="mt-3 text-[#4a5162]">
+        <p class="mt-3 text-[#5f6577]">
           Ranked in the top 2% of learners worldwide (Dec 2023) across 72.6M monthly active users.
         </p>
         <div class="mt-4 flex flex-wrap gap-2">
-          <span class="inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-[#4a5162]">96% accuracy</span>
-          <span class="inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-[#4a5162]">1000+ lessons</span>
+          <span class="inline-flex items-center rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-[#5f6577]">96% accuracy</span>
+          <span class="inline-flex items-center rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-[#5f6577]">1000+ lessons</span>
         </div>
       </div>
-      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
-        <h3 class="font-semibold text-xl mb-2 text-[#0c111f]">Languages</h3>
-        <ul class="space-y-2 text-[#4a5162]">
+      <div class="rounded-2xl border border-white/70 bg-white/90 p-6">
+        <h3 class="font-semibold text-xl mb-2 text-[#2f3447]">Languages</h3>
+        <ul class="space-y-2 text-[#5f6577]">
           <li>English — Native/Bilingual</li>
           <li>German — Native/Bilingual</li>
           <li>Spanish — Professional Working Proficiency</li>
@@ -101,43 +101,43 @@
     </div>
   </div>
 
-  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/80 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Outside Tech</p>
-      <h2 class="text-3xl font-semibold text-[#0c111f]">Hobbies</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Outside Tech</p>
+      <h2 class="text-3xl font-semibold text-[#2f3447]">Hobbies</h2>
     </div>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🥁</span>
-        <span class="font-medium text-[#0c111f]">Drums</span>
+        <span class="font-medium text-[#2f3447]">Drums</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🎸</span>
-        <span class="font-medium text-[#0c111f]">Guitar</span>
+        <span class="font-medium text-[#2f3447]">Guitar</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🎮</span>
-        <span class="font-medium text-[#0c111f]">Gaming</span>
+        <span class="font-medium text-[#2f3447]">Gaming</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏄‍♂️</span>
-        <span class="font-medium text-[#0c111f]">Surfing</span>
+        <span class="font-medium text-[#2f3447]">Surfing</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏂</span>
-        <span class="font-medium text-[#0c111f]">Snowboarding</span>
+        <span class="font-medium text-[#2f3447]">Snowboarding</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🚴‍♂️</span>
-        <span class="font-medium text-[#0c111f]">Cycling</span>
+        <span class="font-medium text-[#2f3447]">Cycling</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏋️‍♂️</span>
-        <span class="font-medium text-[#0c111f]">Fitness</span>
+        <span class="font-medium text-[#2f3447]">Fitness</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/90 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏃‍♂️</span>
-        <span class="font-medium text-[#0c111f]">Running</span>
+        <span class="font-medium text-[#2f3447]">Running</span>
       </div>
     </div>
   </div>

--- a/src/components/AboutMain.html
+++ b/src/components/AboutMain.html
@@ -1,7 +1,7 @@
 <section class="flex flex-col gap-10 w-full mx-auto px-[1.5rem] max-w-[83rem] text-lg text-[#3d4663] md:text-xl">
-  <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
+  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
     <div class="space-y-2">
-      <p class="text-accent font-medium tracking-wide">CURRENT FOCUS</p>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Current Focus</p>
       <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Developer Experience</h2>
     </div>
     <div class="space-y-4">
@@ -11,11 +11,11 @@
         recompilation delays and allows teams to stay in flow while building modern web apps.
       </p>
       <div class="grid gap-4 md:grid-cols-2">
-        <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
           <p class="font-semibold text-[#090b11]">Focus Areas</p>
           <p class="mt-2 text-gray-600">Component-level hot reload, state preservation, and zero-distraction feedback loops.</p>
         </div>
-        <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
           <p class="font-semibold text-[#090b11]">Why It Matters</p>
           <p class="mt-2 text-gray-600">Faster iteration cycles, improved team velocity, and a more enjoyable development process.</p>
         </div>
@@ -23,27 +23,27 @@
     </div>
   </div>
 
-  <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
+  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
     <div class="space-y-2">
-      <p class="text-accent font-medium tracking-wide">EXPERIENCE</p>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Experience</p>
       <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Career Timeline</h2>
     </div>
     <div class="space-y-6">
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
           <h3 class="font-semibold text-xl text-[#090b11]">Senior Frontend Engineer · YAZIO</h3>
           <span class="text-sm text-gray-500">Mar 2024 — Present · Remote</span>
         </div>
         <p class="mt-3 text-gray-600">Leading frontend delivery for high-scale consumer web experiences.</p>
       </div>
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
           <h3 class="font-semibold text-xl text-[#090b11]">Lead Software Engineer · MaibornWolff</h3>
           <span class="text-sm text-gray-500">Feb 2024 — Mar 2024 · Valencia</span>
         </div>
         <p class="mt-3 text-gray-600">Short-term leadership role focused on delivery excellence and team enablement.</p>
       </div>
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
           <h3 class="font-semibold text-xl text-[#090b11]">Full-Stack Software Engineer · BMW Group</h3>
           <span class="text-sm text-gray-500">Jan 2020 — Oct 2023 · Greenville, SC</span>
@@ -55,7 +55,7 @@
           <li>Delivered Angular 10 smart charging platform and Angular 12 + NestJS smart ticket platform.</li>
         </ul>
       </div>
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
           <h3 class="font-semibold text-xl text-[#090b11]">Software Developer · Arvato Systems</h3>
           <span class="text-sm text-gray-500">Sep 2012 — Jan 2020 · Leipzig/Greenville</span>
@@ -69,13 +69,13 @@
     </div>
   </div>
 
-  <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
+  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
     <div class="space-y-2">
-      <p class="text-accent font-medium tracking-wide">RECOGNITION</p>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Recognition</p>
       <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Honors & Languages</h2>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
-      <div class="p-6 rounded-xl bg-gradient-to-br from-white via-gray-50 to-white border border-gray-100 shadow-sm">
+      <div class="rounded-2xl border border-white/60 bg-gradient-to-br from-white via-white/70 to-white/40 p-6 shadow-sm">
         <div class="flex items-center justify-between gap-4">
           <h3 class="font-semibold text-xl text-[#090b11]">Honors & Awards</h3>
           <span class="inline-flex items-center gap-2 rounded-full bg-accent/10 text-accent px-3 py-1 text-xs font-semibold tracking-wide">
@@ -90,7 +90,7 @@
           <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">1000+ lessons</span>
         </div>
       </div>
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
         <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Languages</h3>
         <ul class="space-y-2 text-gray-600">
           <li>English — Native/Bilingual</li>
@@ -101,41 +101,41 @@
     </div>
   </div>
 
-  <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
+  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
     <div class="space-y-2">
-      <p class="text-accent font-medium tracking-wide">OUTSIDE TECH</p>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Outside Tech</p>
       <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Hobbies</h2>
     </div>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🥁</span>
         <span class="font-medium text-[#090b11]">Drums</span>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🎸</span>
         <span class="font-medium text-[#090b11]">Guitar</span>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🎮</span>
         <span class="font-medium text-[#090b11]">Gaming</span>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏄‍♂️</span>
         <span class="font-medium text-[#090b11]">Surfing</span>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏂</span>
         <span class="font-medium text-[#090b11]">Snowboarding</span>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🚴‍♂️</span>
         <span class="font-medium text-[#090b11]">Cycling</span>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏋️‍♂️</span>
         <span class="font-medium text-[#090b11]">Fitness</span>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏃‍♂️</span>
         <span class="font-medium text-[#090b11]">Running</span>
       </div>

--- a/src/components/AboutMain.html
+++ b/src/components/AboutMain.html
@@ -1,8 +1,8 @@
-<section class="flex flex-col gap-10 w-full mx-auto px-[1.5rem] max-w-[83rem] text-lg text-[#3d4663] md:text-xl">
-  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
+<section class="flex flex-col gap-12 w-full mx-auto px-[1.5rem] max-w-[83rem] text-lg text-[#4a5162] md:text-xl">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Current Focus</p>
-      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Developer Experience</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Current Focus</p>
+      <h2 class="text-3xl font-semibold text-[#0c111f]">Developer Experience</h2>
     </div>
     <div class="space-y-4">
       <p>
@@ -11,56 +11,56 @@
         recompilation delays and allows teams to stay in flow while building modern web apps.
       </p>
       <div class="grid gap-4 md:grid-cols-2">
-        <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
-          <p class="font-semibold text-[#090b11]">Focus Areas</p>
-          <p class="mt-2 text-gray-600">Component-level hot reload, state preservation, and zero-distraction feedback loops.</p>
+        <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
+          <p class="font-semibold text-[#0c111f]">Focus Areas</p>
+          <p class="mt-2 text-[#4a5162]">Component-level hot reload, state preservation, and zero-distraction feedback loops.</p>
         </div>
-        <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
-          <p class="font-semibold text-[#090b11]">Why It Matters</p>
-          <p class="mt-2 text-gray-600">Faster iteration cycles, improved team velocity, and a more enjoyable development process.</p>
+        <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
+          <p class="font-semibold text-[#0c111f]">Why It Matters</p>
+          <p class="mt-2 text-[#4a5162]">Faster iteration cycles, improved team velocity, and a more enjoyable development process.</p>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Experience</p>
-      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Career Timeline</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Experience</p>
+      <h2 class="text-3xl font-semibold text-[#0c111f]">Career Timeline</h2>
     </div>
     <div class="space-y-6">
-      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#090b11]">Senior Frontend Engineer · YAZIO</h3>
+          <h3 class="font-semibold text-xl text-[#0c111f]">Senior Frontend Engineer · YAZIO</h3>
           <span class="text-sm text-gray-500">Mar 2024 — Present · Remote</span>
         </div>
-        <p class="mt-3 text-gray-600">Leading frontend delivery for high-scale consumer web experiences.</p>
+        <p class="mt-3 text-[#4a5162]">Leading frontend delivery for high-scale consumer web experiences.</p>
       </div>
-      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#090b11]">Lead Software Engineer · MaibornWolff</h3>
+          <h3 class="font-semibold text-xl text-[#0c111f]">Lead Software Engineer · MaibornWolff</h3>
           <span class="text-sm text-gray-500">Feb 2024 — Mar 2024 · Valencia</span>
         </div>
-        <p class="mt-3 text-gray-600">Short-term leadership role focused on delivery excellence and team enablement.</p>
+        <p class="mt-3 text-[#4a5162]">Short-term leadership role focused on delivery excellence and team enablement.</p>
       </div>
-      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#090b11]">Full-Stack Software Engineer · BMW Group</h3>
+          <h3 class="font-semibold text-xl text-[#0c111f]">Full-Stack Software Engineer · BMW Group</h3>
           <span class="text-sm text-gray-500">Jan 2020 — Oct 2023 · Greenville, SC</span>
         </div>
-        <ul class="mt-3 space-y-2 text-gray-600 list-disc list-inside">
+        <ul class="mt-3 space-y-2 text-[#4a5162] list-disc list-inside">
           <li>Led Gatsby + React marketing site build from scratch.</li>
           <li>Built a TypeScript-driven testing pipeline (TestCafe, Jenkins, Jira reporters).</li>
           <li>Improved Lighthouse scores to 97–100 across performance, accessibility, best practices, and SEO.</li>
           <li>Delivered Angular 10 smart charging platform and Angular 12 + NestJS smart ticket platform.</li>
         </ul>
       </div>
-      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
+      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
         <div class="flex flex-wrap items-center justify-between gap-2">
-          <h3 class="font-semibold text-xl text-[#090b11]">Software Developer · Arvato Systems</h3>
+          <h3 class="font-semibold text-xl text-[#0c111f]">Software Developer · Arvato Systems</h3>
           <span class="text-sm text-gray-500">Sep 2012 — Jan 2020 · Leipzig/Greenville</span>
         </div>
-        <ul class="mt-3 space-y-2 text-gray-600 list-disc list-inside">
+        <ul class="mt-3 space-y-2 text-[#4a5162] list-disc list-inside">
           <li>Built modern web platforms and mobile-first experiences for global enterprises.</li>
           <li>Improved performance by reducing start page payloads and load times on 3G networks.</li>
           <li>Led test management for a 20+ person team on a major retail project.</li>
@@ -69,30 +69,30 @@
     </div>
   </div>
 
-  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Recognition</p>
-      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Honors & Languages</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Recognition</p>
+      <h2 class="text-3xl font-semibold text-[#0c111f]">Honors & Languages</h2>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
-      <div class="rounded-2xl border border-white/60 bg-gradient-to-br from-white via-white/70 to-white/40 p-6 shadow-sm">
+      <div class="rounded-2xl border border-white/70 bg-gradient-to-br from-white via-white/70 to-white/40 p-6 shadow-sm">
         <div class="flex items-center justify-between gap-4">
-          <h3 class="font-semibold text-xl text-[#090b11]">Honors & Awards</h3>
-          <span class="inline-flex items-center gap-2 rounded-full bg-accent/10 text-accent px-3 py-1 text-xs font-semibold tracking-wide">
+          <h3 class="font-semibold text-xl text-[#0c111f]">Honors & Awards</h3>
+          <span class="inline-flex items-center gap-2 rounded-full bg-[#2662ff]/10 text-[#2662ff] px-3 py-1 text-xs font-semibold tracking-wide">
             Top 2% • Duolingo
           </span>
         </div>
-        <p class="mt-3 text-gray-600">
+        <p class="mt-3 text-[#4a5162]">
           Ranked in the top 2% of learners worldwide (Dec 2023) across 72.6M monthly active users.
         </p>
         <div class="mt-4 flex flex-wrap gap-2">
-          <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">96% accuracy</span>
-          <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">1000+ lessons</span>
+          <span class="inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-[#4a5162]">96% accuracy</span>
+          <span class="inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-[#4a5162]">1000+ lessons</span>
         </div>
       </div>
-      <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
-        <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Languages</h3>
-        <ul class="space-y-2 text-gray-600">
+      <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
+        <h3 class="font-semibold text-xl mb-2 text-[#0c111f]">Languages</h3>
+        <ul class="space-y-2 text-[#4a5162]">
           <li>English — Native/Bilingual</li>
           <li>German — Native/Bilingual</li>
           <li>Spanish — Professional Working Proficiency</li>
@@ -101,43 +101,43 @@
     </div>
   </div>
 
-  <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
+  <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
     <div class="space-y-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Outside Tech</p>
-      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Hobbies</h2>
+      <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Outside Tech</p>
+      <h2 class="text-3xl font-semibold text-[#0c111f]">Hobbies</h2>
     </div>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🥁</span>
-        <span class="font-medium text-[#090b11]">Drums</span>
+        <span class="font-medium text-[#0c111f]">Drums</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🎸</span>
-        <span class="font-medium text-[#090b11]">Guitar</span>
+        <span class="font-medium text-[#0c111f]">Guitar</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🎮</span>
-        <span class="font-medium text-[#090b11]">Gaming</span>
+        <span class="font-medium text-[#0c111f]">Gaming</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏄‍♂️</span>
-        <span class="font-medium text-[#090b11]">Surfing</span>
+        <span class="font-medium text-[#0c111f]">Surfing</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏂</span>
-        <span class="font-medium text-[#090b11]">Snowboarding</span>
+        <span class="font-medium text-[#0c111f]">Snowboarding</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🚴‍♂️</span>
-        <span class="font-medium text-[#090b11]">Cycling</span>
+        <span class="font-medium text-[#0c111f]">Cycling</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏋️‍♂️</span>
-        <span class="font-medium text-[#090b11]">Fitness</span>
+        <span class="font-medium text-[#0c111f]">Fitness</span>
       </div>
-      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/60 bg-white/70 p-6 transition-all duration-300 hover:-translate-y-1">
+      <div class="flex flex-col items-center gap-3 rounded-2xl border border-white/70 bg-white/80 p-6 transition-all duration-300 hover:-translate-y-1">
         <span class="text-4xl">🏃‍♂️</span>
-        <span class="font-medium text-[#090b11]">Running</span>
+        <span class="font-medium text-[#0c111f]">Running</span>
       </div>
     </div>
   </div>

--- a/src/components/AboutMain.html
+++ b/src/components/AboutMain.html
@@ -75,10 +75,20 @@
       <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Honors & Languages</h2>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
-        <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Honors & Awards</h3>
-        <p class="text-gray-600">Top 2% of all Duolingo learners worldwide (Dec 2023).</p>
-        <p class="mt-2 text-gray-600">Recognized for 96% accuracy with 1000+ lessons completed.</p>
+      <div class="p-6 rounded-xl bg-gradient-to-br from-white via-gray-50 to-white border border-gray-100 shadow-sm">
+        <div class="flex items-center justify-between gap-4">
+          <h3 class="font-semibold text-xl text-[#090b11]">Honors & Awards</h3>
+          <span class="inline-flex items-center gap-2 rounded-full bg-accent/10 text-accent px-3 py-1 text-xs font-semibold tracking-wide">
+            Top 2% • Duolingo
+          </span>
+        </div>
+        <p class="mt-3 text-gray-600">
+          Ranked in the top 2% of learners worldwide (Dec 2023) across 72.6M monthly active users.
+        </p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">96% accuracy</span>
+          <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">1000+ lessons</span>
+        </div>
       </div>
       <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
         <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Languages</h3>

--- a/src/components/AboutMain.html
+++ b/src/components/AboutMain.html
@@ -1,103 +1,92 @@
 <section class="flex flex-col gap-10 w-full mx-auto px-[1.5rem] max-w-[83rem] text-lg text-[#3d4663] md:text-xl">
   <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
     <div class="space-y-2">
-      <p class="text-accent font-medium tracking-wide">MY JOURNEY</p>
-      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Background</h2>
+      <p class="text-accent font-medium tracking-wide">CURRENT FOCUS</p>
+      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Developer Experience</h2>
     </div>
-    <div class="space-y-6">
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-colors duration-300">
-        <p class="flex items-center gap-3">
-          <span class="text-2xl">🇩🇪</span>
-          Born and raised in Germany, where I developed my foundation in software engineering and computer science
-        </p>
-      </div>
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-colors duration-300">
-        <p class="flex items-center gap-3">
-          <span class="text-2xl">🇺🇲</span>
-          Expanded my career in the United States, working with innovative tech companies and diverse teams
-        </p>
-      </div>
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-colors duration-300">
-        <p class="flex items-center gap-3">
-          <span class="text-2xl">🇪🇸</span>
-          Currently based in Valencia, Spain, where I continue to push boundaries in web development and technology
-        </p>
+    <div class="space-y-4">
+      <p>
+        Developing a next-generation HMR and React Fast Refresh workflow that lets developers iterate on components
+        without losing state or context. The goal is a seamless, fluid development experience that removes
+        recompilation delays and allows teams to stay in flow while building modern web apps.
+      </p>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+          <p class="font-semibold text-[#090b11]">Focus Areas</p>
+          <p class="mt-2 text-gray-600">Component-level hot reload, state preservation, and zero-distraction feedback loops.</p>
+        </div>
+        <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+          <p class="font-semibold text-[#090b11]">Why It Matters</p>
+          <p class="mt-2 text-gray-600">Faster iteration cycles, improved team velocity, and a more enjoyable development process.</p>
+        </div>
       </div>
     </div>
   </div>
 
   <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
     <div class="space-y-2">
-      <p class="text-accent font-medium tracking-wide">QUALIFICATIONS</p>
-      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Education</h2>
+      <p class="text-accent font-medium tracking-wide">EXPERIENCE</p>
+      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Career Timeline</h2>
     </div>
     <div class="space-y-6">
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-colors duration-300">
-        <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Computer Science Degree</h3>
-        <p>BSZ7 Leipzig (2015) - Major: System Integration</p>
-        <p class="mt-2 text-gray-600">Focused on software architecture, system design, and integration patterns</p>
+      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h3 class="font-semibold text-xl text-[#090b11]">Senior Frontend Engineer · YAZIO</h3>
+          <span class="text-sm text-gray-500">Mar 2024 — Present · Remote</span>
+        </div>
+        <p class="mt-3 text-gray-600">Leading frontend delivery for high-scale consumer web experiences.</p>
       </div>
-      
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-colors duration-300">
-        <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Google Chrome Mobile Web Specialist</h3>
-        <p>Comprehensive 6-month nanodegree program in collaboration with Google Chrome Developer team</p>
-        <ul class="mt-3 space-y-2 text-gray-600">
-          <li>• Advanced PWA development</li>
-          <li>• Performance optimization techniques</li>
-          <li>• Modern web development practices</li>
+      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h3 class="font-semibold text-xl text-[#090b11]">Lead Software Engineer · MaibornWolff</h3>
+          <span class="text-sm text-gray-500">Feb 2024 — Mar 2024 · Valencia</span>
+        </div>
+        <p class="mt-3 text-gray-600">Short-term leadership role focused on delivery excellence and team enablement.</p>
+      </div>
+      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h3 class="font-semibold text-xl text-[#090b11]">Full-Stack Software Engineer · BMW Group</h3>
+          <span class="text-sm text-gray-500">Jan 2020 — Oct 2023 · Greenville, SC</span>
+        </div>
+        <ul class="mt-3 space-y-2 text-gray-600 list-disc list-inside">
+          <li>Led Gatsby + React marketing site build from scratch.</li>
+          <li>Built a TypeScript-driven testing pipeline (TestCafe, Jenkins, Jira reporters).</li>
+          <li>Improved Lighthouse scores to 97–100 across performance, accessibility, best practices, and SEO.</li>
+          <li>Delivered Angular 10 smart charging platform and Angular 12 + NestJS smart ticket platform.</li>
         </ul>
       </div>
-
-      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-colors duration-300">
-        <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Continuous Learning</h3>
-        <p>Committed to staying at the forefront of web development technologies</p>
-        <a href="https://www.linkedin.com/in/jdrechslerus" class="inline-flex items-center gap-2 mt-4 text-accent hover:text-[#090b11] transition-colors group">
-          View my complete education history
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="transition-transform group-hover:translate-x-1">
-            <path d="M7 7l10 10M7 17V7h10"/>
-          </svg>
-        </a>
+      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h3 class="font-semibold text-xl text-[#090b11]">Software Developer · Arvato Systems</h3>
+          <span class="text-sm text-gray-500">Sep 2012 — Jan 2020 · Leipzig/Greenville</span>
+        </div>
+        <ul class="mt-3 space-y-2 text-gray-600 list-disc list-inside">
+          <li>Built modern web platforms and mobile-first experiences for global enterprises.</li>
+          <li>Improved performance by reducing start page payloads and load times on 3G networks.</li>
+          <li>Led test management for a 20+ person team on a major retail project.</li>
+        </ul>
       </div>
     </div>
   </div>
 
   <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
     <div class="space-y-2">
-      <p class="text-accent font-medium tracking-wide">OUTSIDE TECH</p>
-      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Hobbies</h2>
+      <p class="text-accent font-medium tracking-wide">RECOGNITION</p>
+      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Honors & Languages</h2>
     </div>
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🥁</span>
-        <span class="font-medium text-[#090b11]">Drums</span>
+    <div class="grid gap-6 md:grid-cols-2">
+      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Honors & Awards</h3>
+        <p class="text-gray-600">Top 2% of all Duolingo learners worldwide (Dec 2023).</p>
+        <p class="mt-2 text-gray-600">Recognized for 96% accuracy with 1000+ lessons completed.</p>
       </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🎸</span>
-        <span class="font-medium text-[#090b11]">Guitar</span>
-      </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🎮</span>
-        <span class="font-medium text-[#090b11]">Gaming</span>
-      </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🏄‍♂️</span>
-        <span class="font-medium text-[#090b11]">Surfing</span>
-      </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🏂</span>
-        <span class="font-medium text-[#090b11]">Snowboarding</span>
-      </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🚴‍♂️</span>
-        <span class="font-medium text-[#090b11]">Cycling</span>
-      </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🏋️‍♂️</span>
-        <span class="font-medium text-[#090b11]">Fitness</span>
-      </div>
-      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
-        <span class="text-4xl">🏃‍♂️</span>
-        <span class="font-medium text-[#090b11]">Running</span>
+      <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+        <h3 class="font-semibold text-xl mb-2 text-[#090b11]">Languages</h3>
+        <ul class="space-y-2 text-gray-600">
+          <li>English — Native/Bilingual</li>
+          <li>German — Native/Bilingual</li>
+          <li>Spanish — Professional Working Proficiency</li>
+        </ul>
       </div>
     </div>
   </div>

--- a/src/components/AboutMain.html
+++ b/src/components/AboutMain.html
@@ -90,4 +90,45 @@
       </div>
     </div>
   </div>
+
+  <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
+    <div class="space-y-2">
+      <p class="text-accent font-medium tracking-wide">OUTSIDE TECH</p>
+      <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Hobbies</h2>
+    </div>
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🥁</span>
+        <span class="font-medium text-[#090b11]">Drums</span>
+      </div>
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🎸</span>
+        <span class="font-medium text-[#090b11]">Guitar</span>
+      </div>
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🎮</span>
+        <span class="font-medium text-[#090b11]">Gaming</span>
+      </div>
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🏄‍♂️</span>
+        <span class="font-medium text-[#090b11]">Surfing</span>
+      </div>
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🏂</span>
+        <span class="font-medium text-[#090b11]">Snowboarding</span>
+      </div>
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🚴‍♂️</span>
+        <span class="font-medium text-[#090b11]">Cycling</span>
+      </div>
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🏋️‍♂️</span>
+        <span class="font-medium text-[#090b11]">Fitness</span>
+      </div>
+      <div class="flex flex-col items-center gap-3 p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm hover:bg-gray-50 transition-all duration-300 hover:-translate-y-1">
+        <span class="text-4xl">🏃‍♂️</span>
+        <span class="font-medium text-[#090b11]">Running</span>
+      </div>
+    </div>
+  </div>
 </section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,30 +2,36 @@
 const currentYear = new Date().getFullYear()
 ---
 
-<footer class="mt-16">
+<footer class="mt-20">
   <div
-    class="mx-auto w-[min(92rem,92%)] rounded-[2.5rem] border border-white/60 bg-white/70 p-8 text-[#6474a2] shadow-[0_25px_60px_rgba(15,23,42,0.08)] backdrop-blur-xl"
+    class="mx-auto w-[min(92rem,92%)] rounded-[2.75rem] border border-white/70 bg-white/75 p-8 text-[#4a5162] shadow-[0_25px_60px_rgba(15,23,42,0.08)] backdrop-blur-xl"
   >
     <div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
       <div class="space-y-2 text-center lg:text-left">
-        <p class="text-sm uppercase tracking-[0.3em] text-[#2f6bff]">Based in Valencia</p>
-        <p class="text-base text-[#0b0f1a]">
+        <p class="text-sm uppercase tracking-[0.35em] text-[#2662ff]">Based in Valencia</p>
+        <p class="text-base text-[#0c111f]">
           Designed & Developed in Valencia, Spain
           <span class="text-xl">&#127774;</span>
         </p>
         <p class="text-sm">© {currentYear} Johannes Drechsler</p>
       </div>
-      <ul class="flex flex-wrap items-center justify-center gap-4 text-sm font-semibold text-[#0b0f1a]">
+      <div class="flex flex-col items-center gap-4 sm:flex-row">
+        <div class="flex items-center gap-2">
+          <span class="h-1.5 w-1.5 rounded-full bg-[#2662ff]"></span>
+          <span class="text-sm font-semibold text-[#0c111f]">Open to collaborations</span>
+        </div>
+        <ul class="flex flex-wrap items-center justify-center gap-4 text-sm font-semibold text-[#0c111f]">
         <li>
-          <a class="rounded-full bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://github.com/JDrechsler">GitHub</a>
+          <a class="rounded-full border border-white/70 bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://github.com/JDrechsler">GitHub</a>
         </li>
         <li>
-          <a class="rounded-full bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://www.linkedin.com/in/jdrechslerus">LinkedIn</a>
+          <a class="rounded-full border border-white/70 bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://www.linkedin.com/in/jdrechslerus">LinkedIn</a>
         </li>
         <li>
-          <a class="rounded-full bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://twitter.com/JDrechslerUS">X (Twitter)</a>
+          <a class="rounded-full border border-white/70 bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://twitter.com/JDrechslerUS">X (Twitter)</a>
         </li>
       </ul>
+      </div>
     </div>
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,25 +2,30 @@
 const currentYear = new Date().getFullYear()
 ---
 
-<footer>
+<footer class="mt-16">
   <div
-    class="p-8 text-[#6474a2] flex flex-col items-center gap-8 lg:flex-row lg:justify-evenly lg:items-baseline"
+    class="mx-auto w-[min(92rem,92%)] rounded-[2.5rem] border border-white/60 bg-white/70 p-8 text-[#6474a2] shadow-[0_25px_60px_rgba(15,23,42,0.08)] backdrop-blur-xl"
   >
-    <div
-      class="flex flex-col items-center gap-x-2 gap-y-1 md:flex-row md:items-baseline"
-    >
-      <p>
-        Designed & Developed in Valencia, Spain
-        <span class="text-xl">&#127774;</span>
-      </p>
-      <p>© {currentYear} Johannes Drechsler</p>
+    <div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+      <div class="space-y-2 text-center lg:text-left">
+        <p class="text-sm uppercase tracking-[0.3em] text-[#2f6bff]">Based in Valencia</p>
+        <p class="text-base text-[#0b0f1a]">
+          Designed & Developed in Valencia, Spain
+          <span class="text-xl">&#127774;</span>
+        </p>
+        <p class="text-sm">© {currentYear} Johannes Drechsler</p>
+      </div>
+      <ul class="flex flex-wrap items-center justify-center gap-4 text-sm font-semibold text-[#0b0f1a]">
+        <li>
+          <a class="rounded-full bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://github.com/JDrechsler">GitHub</a>
+        </li>
+        <li>
+          <a class="rounded-full bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://www.linkedin.com/in/jdrechslerus">LinkedIn</a>
+        </li>
+        <li>
+          <a class="rounded-full bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://twitter.com/JDrechslerUS">X (Twitter)</a>
+        </li>
+      </ul>
     </div>
-    <ul class="flex items-center justify-center gap-x-5 gap-y-1 flex-wrap">
-      <li><a href="https://github.com/JDrechsler">GitHub</a></li>
-      <li><a href="https://www.linkedin.com/in/jdrechslerus">LinkedIn</a></li>
-      <li>
-        <a href="https://twitter.com/JDrechslerUS">X - Formerly Twitter</a>
-      </li>
-    </ul>
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,12 +4,12 @@ const currentYear = new Date().getFullYear()
 
 <footer class="mt-20">
   <div
-    class="mx-auto w-[min(92rem,92%)] rounded-[2.75rem] border border-white/70 bg-white/75 p-8 text-[#4a5162] shadow-[0_25px_60px_rgba(15,23,42,0.08)] backdrop-blur-xl"
+    class="mx-auto w-[min(92rem,92%)] rounded-[2.75rem] border border-white/70 bg-white/85 p-8 text-[#5f6577] shadow-[0_25px_60px_rgba(45,42,36,0.08)] backdrop-blur-xl"
   >
     <div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
       <div class="space-y-2 text-center lg:text-left">
-        <p class="text-sm uppercase tracking-[0.35em] text-[#2662ff]">Based in Valencia</p>
-        <p class="text-base text-[#0c111f]">
+        <p class="text-sm uppercase tracking-[0.35em] text-[#e8895e]">Based in Valencia</p>
+        <p class="text-base text-[#2f3447]">
           Designed & Developed in Valencia, Spain
           <span class="text-xl">&#127774;</span>
         </p>
@@ -17,18 +17,18 @@ const currentYear = new Date().getFullYear()
       </div>
       <div class="flex flex-col items-center gap-4 sm:flex-row">
         <div class="flex items-center gap-2">
-          <span class="h-1.5 w-1.5 rounded-full bg-[#2662ff]"></span>
-          <span class="text-sm font-semibold text-[#0c111f]">Open to collaborations</span>
+          <span class="h-1.5 w-1.5 rounded-full bg-[#f08a5d]"></span>
+          <span class="text-sm font-semibold text-[#2f3447]">Open to collaborations</span>
         </div>
-        <ul class="flex flex-wrap items-center justify-center gap-4 text-sm font-semibold text-[#0c111f]">
+        <ul class="flex flex-wrap items-center justify-center gap-4 text-sm font-semibold text-[#2f3447]">
         <li>
-          <a class="rounded-full border border-white/70 bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://github.com/JDrechsler">GitHub</a>
+          <a class="rounded-full border border-white/70 bg-white/90 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://github.com/JDrechsler">GitHub</a>
         </li>
         <li>
-          <a class="rounded-full border border-white/70 bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://www.linkedin.com/in/jdrechslerus">LinkedIn</a>
+          <a class="rounded-full border border-white/70 bg-white/90 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://www.linkedin.com/in/jdrechslerus">LinkedIn</a>
         </li>
         <li>
-          <a class="rounded-full border border-white/70 bg-white/80 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://twitter.com/JDrechslerUS">X (Twitter)</a>
+          <a class="rounded-full border border-white/70 bg-white/90 px-4 py-2 shadow-sm transition hover:-translate-y-0.5" href="https://twitter.com/JDrechslerUS">X (Twitter)</a>
         </li>
       </ul>
       </div>

--- a/src/components/Hero.html
+++ b/src/components/Hero.html
@@ -151,6 +151,8 @@
       </ul>
     </div>
     <div class="relative">
+      <div class="absolute -right-10 top-10 hidden h-40 w-40 rounded-full bg-gradient-to-br from-[#f08a5d] via-[#f7b267] to-[#ffd6a5] opacity-80 blur-2xl animate-float-slow md:block"></div>
+      <div class="absolute -left-6 bottom-10 hidden h-28 w-28 rounded-full bg-gradient-to-br from-[#fbd1b0] via-[#f7b267] to-[#f08a5d] opacity-70 blur-xl animate-float-fast md:block"></div>
       <div class="absolute inset-3 rounded-[2.5rem] border border-white/70"></div>
       <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-tr from-[#f08a5d]/25 via-white/20 to-[#f7b267]/25 blur-2xl"></div>
       <img

--- a/src/components/Hero.html
+++ b/src/components/Hero.html
@@ -3,18 +3,15 @@
     class="relative grid gap-12 md:grid-cols-[1.1fr,0.9fr] lg:px-[2.5rem]"
   >
     <div class="flex flex-col gap-6 text-left">
-      <div class="inline-flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">
-        <span class="h-2 w-2 rounded-full bg-[#2662ff]"></span>
-        Full-stack engineer
+      <div class="inline-flex items-center gap-3 rounded-full bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[#e8895e] shadow-sm">
+        Full-Stack Engineer
       </div>
       <h1
-        class="text-[42px] font-semibold tracking-tight text-[#0c111f] md:text-7xl"
+        class="text-[42px] font-semibold tracking-tight text-[#2f3447] md:text-7xl"
       >
-        Designing fast, human web experiences for ambitious teams.
+        Hi, I’m Johannes Drechsler.
       </h1>
-      <p
-        class="text-lg text-[#4a5162] md:text-[22px] md:leading-[36px]"
-      >
+      <p class="text-lg text-[#5f6577] md:text-[22px] md:leading-[36px]">
         I’m Johannes Drechsler — a certified full-stack software engineer with
         10+ years of experience crafting accessible, high-performance web
         experiences for global teams.
@@ -22,35 +19,35 @@
       <div class="flex flex-wrap items-center gap-4">
         <a
           href="/work"
-          class="inline-flex items-center gap-2 rounded-full bg-[#0c111f] px-6 py-3 text-sm font-semibold text-white shadow-[0_12px_30px_rgba(12,17,31,0.2)] transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#f08a5d] to-[#f7b267] px-6 py-3 text-sm font-semibold text-white shadow-[0_12px_30px_rgba(240,138,93,0.3)] transition hover:-translate-y-0.5"
         >
           View Work
           <span class="text-lg">→</span>
         </a>
         <a
           href="/about"
-          class="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-6 py-3 text-sm font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/90 px-6 py-3 text-sm font-semibold text-[#2f3447] shadow-sm transition hover:-translate-y-0.5"
         >
           About Me
         </a>
       </div>
-      <div class="grid gap-4 rounded-[2rem] border border-white/70 bg-white/70 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:grid-cols-3">
+      <div class="grid gap-4 rounded-[2rem] border border-white/70 bg-white/85 p-6 shadow-[0_20px_45px_rgba(45,42,36,0.08)] md:grid-cols-3">
         <div>
-          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Experience</p>
-          <p class="mt-2 text-2xl font-semibold text-[#0c111f]">10+ years</p>
+          <p class="text-xs uppercase tracking-[0.3em] text-[#9c8f86]">Experience</p>
+          <p class="mt-2 text-2xl font-semibold text-[#2f3447]">10+ years</p>
         </div>
         <div>
-          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Focus</p>
-          <p class="mt-2 text-2xl font-semibold text-[#0c111f]">DX + Web</p>
+          <p class="text-xs uppercase tracking-[0.3em] text-[#9c8f86]">Focus</p>
+          <p class="mt-2 text-2xl font-semibold text-[#2f3447]">DX + Web</p>
         </div>
         <div>
-          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Based</p>
-          <p class="mt-2 text-2xl font-semibold text-[#0c111f]">Valencia</p>
+          <p class="text-xs uppercase tracking-[0.3em] text-[#9c8f86]">Based</p>
+          <p class="mt-2 text-2xl font-semibold text-[#2f3447]">Valencia</p>
         </div>
       </div>
       <ul class="flex flex-wrap gap-3">
         <li
-          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f]"
+          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/90 px-4 py-2 text-sm font-semibold text-[#2f3447]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -72,7 +69,7 @@
           ><span>Developer</span>
         </li>
         <li
-          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f]"
+          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/90 px-4 py-2 text-sm font-semibold text-[#2f3447]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -103,7 +100,7 @@
           ><span>Musician</span>
         </li>
         <li
-          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f]"
+          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/90 px-4 py-2 text-sm font-semibold text-[#2f3447]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -154,10 +151,10 @@
       </ul>
     </div>
     <div class="relative">
-      <div class="absolute inset-4 rounded-[2.5rem] border border-white/60"></div>
-      <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-tr from-[#2662ff]/20 via-white/10 to-[#ff8c78]/20 blur-2xl"></div>
+      <div class="absolute inset-3 rounded-[2.5rem] border border-white/70"></div>
+      <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-tr from-[#f08a5d]/25 via-white/20 to-[#f7b267]/25 blur-2xl"></div>
       <img
-        class="relative w-full rounded-[2.5rem] border border-white/70 bg-white/80 object-cover shadow-[0_30px_70px_rgba(15,23,42,0.18)]"
+        class="relative w-full rounded-[2.5rem] border border-white/80 bg-white/80 object-cover shadow-[0_30px_70px_rgba(45,42,36,0.18)]"
         src="/assets/profile.jpg"
         alt="Myself in Daytona Beach, Florida"
       />

--- a/src/components/Hero.html
+++ b/src/components/Hero.html
@@ -1,41 +1,56 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
   <section
-    class="relative grid gap-10 text-center md:grid-cols-[1.15fr,0.85fr] md:text-left lg:px-[2.5rem]"
+    class="relative grid gap-12 md:grid-cols-[1.1fr,0.9fr] lg:px-[2.5rem]"
   >
-    <div class="flex flex-col gap-6">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-[#2f6bff]">
+    <div class="flex flex-col gap-6 text-left">
+      <div class="inline-flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">
+        <span class="h-2 w-2 rounded-full bg-[#2662ff]"></span>
         Full-stack engineer
-      </p>
+      </div>
       <h1
-        class="text-[42px] font-semibold tracking-tight text-[#0b0f1a] md:text-7xl"
+        class="text-[42px] font-semibold tracking-tight text-[#0c111f] md:text-7xl"
       >
-        Building products that feel effortless, fast, and human.
+        Designing fast, human web experiences for ambitious teams.
       </h1>
       <p
-        class="text-lg text-[#3d4663] md:text-[22px] md:leading-[36px]"
+        class="text-lg text-[#4a5162] md:text-[22px] md:leading-[36px]"
       >
         I’m Johannes Drechsler — a certified full-stack software engineer with
         10+ years of experience crafting accessible, high-performance web
         experiences for global teams.
       </p>
-      <div class="flex flex-wrap items-center justify-center gap-4 md:justify-start">
+      <div class="flex flex-wrap items-center gap-4">
         <a
           href="/work"
-          class="inline-flex items-center gap-2 rounded-full bg-[#0b0f1a] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full bg-[#0c111f] px-6 py-3 text-sm font-semibold text-white shadow-[0_12px_30px_rgba(12,17,31,0.2)] transition hover:-translate-y-0.5"
         >
           View Work
           <span class="text-lg">→</span>
         </a>
         <a
           href="/about"
-          class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-6 py-3 text-sm font-semibold text-[#0b0f1a] shadow-sm transition hover:-translate-y-0.5"
+          class="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-6 py-3 text-sm font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5"
         >
           About Me
         </a>
       </div>
-      <ul class="flex flex-wrap justify-center gap-3 md:justify-start">
+      <div class="grid gap-4 rounded-[2rem] border border-white/70 bg-white/70 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.08)] md:grid-cols-3">
+        <div>
+          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Experience</p>
+          <p class="mt-2 text-2xl font-semibold text-[#0c111f]">10+ years</p>
+        </div>
+        <div>
+          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Focus</p>
+          <p class="mt-2 text-2xl font-semibold text-[#0c111f]">DX + Web</p>
+        </div>
+        <div>
+          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Based</p>
+          <p class="mt-2 text-2xl font-semibold text-[#0c111f]">Valencia</p>
+        </div>
+      </div>
+      <ul class="flex flex-wrap gap-3">
         <li
-          class="flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0b0f1a]"
+          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -57,7 +72,7 @@
           ><span>Developer</span>
         </li>
         <li
-          class="flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0b0f1a]"
+          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -88,7 +103,7 @@
           ><span>Musician</span>
         </li>
         <li
-          class="flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0b0f1a]"
+          class="flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -139,9 +154,10 @@
       </ul>
     </div>
     <div class="relative">
-      <div class="absolute -inset-4 rounded-[3rem] bg-gradient-to-tr from-[#2f6bff]/20 via-white/10 to-[#f59e0b]/20 blur-2xl"></div>
+      <div class="absolute inset-4 rounded-[2.5rem] border border-white/60"></div>
+      <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-tr from-[#2662ff]/20 via-white/10 to-[#ff8c78]/20 blur-2xl"></div>
       <img
-        class="relative w-[420px] max-w-full rounded-[3rem] border border-white/60 bg-white/80 object-cover shadow-[0_20px_60px_rgba(15,23,42,0.2)]"
+        class="relative w-full rounded-[2.5rem] border border-white/70 bg-white/80 object-cover shadow-[0_30px_70px_rgba(15,23,42,0.18)]"
         src="/assets/profile.jpg"
         alt="Myself in Daytona Beach, Florida"
       />

--- a/src/components/Hero.html
+++ b/src/components/Hero.html
@@ -1,22 +1,41 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
   <section
-    class="grid md:grid-cols-[6fr,4fr] gap-x-5 gap-y-5 text-center justify-center justify-items-center items-center gap-y-[2rem] gap-x-[3.75rem] md:text-left lg:px-[2.5rem]"
+    class="relative grid gap-10 text-center md:grid-cols-[1.15fr,0.85fr] md:text-left lg:px-[2.5rem]"
   >
-    <div class="flex flex-col md:gap-5">
+    <div class="flex flex-col gap-6">
+      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-[#2f6bff]">
+        Full-stack engineer
+      </p>
       <h1
-        class="text-[42px] text-[#090b11] font-bold tracking-wider leading-[1.1] md:text-7xl"
+        class="text-[42px] font-semibold tracking-tight text-[#0b0f1a] md:text-7xl"
       >
-        Hello, my name is Johannes Drechsler!
+        Building products that feel effortless, fast, and human.
       </h1>
       <p
-        class="text-xl max-w-[37ch] mx-auto md:mx-0 text-[#3d4663] max-w-3xl !leading-[39px] md:text-[26px]"
+        class="text-lg text-[#3d4663] md:text-[22px] md:leading-[36px]"
       >
-        I am a Full-Stack Software Engineer with a passion for delivering
-        high-quality, performant, and accessible user experiences.
+        I’m Johannes Drechsler — a certified full-stack software engineer with
+        10+ years of experience crafting accessible, high-performance web
+        experiences for global teams.
       </p>
-      <ul class="hidden gap-5 md:flex">
+      <div class="flex flex-wrap items-center justify-center gap-4 md:justify-start">
+        <a
+          href="/work"
+          class="inline-flex items-center gap-2 rounded-full bg-[#0b0f1a] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5"
+        >
+          View Work
+          <span class="text-lg">→</span>
+        </a>
+        <a
+          href="/about"
+          class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-6 py-3 text-sm font-semibold text-[#0b0f1a] shadow-sm transition hover:-translate-y-0.5"
+        >
+          About Me
+        </a>
+      </div>
+      <ul class="flex flex-wrap justify-center gap-3 md:justify-start">
         <li
-          class="bg-accent text-white font-semibold text-lg px-[1rem] py-[0.5rem] flex gap-2 items-center rounded-full"
+          class="flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0b0f1a]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -38,7 +57,7 @@
           ><span>Developer</span>
         </li>
         <li
-          class="bg-accent text-white font-semibold text-lg px-[1rem] py-[0.5rem] flex gap-2 items-center rounded-full"
+          class="flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0b0f1a]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -69,7 +88,7 @@
           ><span>Musician</span>
         </li>
         <li
-          class="bg-accent text-white font-semibold text-lg px-[1rem] py-[0.5rem] flex gap-2 items-center rounded-full"
+          class="flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0b0f1a]"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -119,10 +138,13 @@
         </li>
       </ul>
     </div>
-    <img
-      class="bg-gray-100 rounded-[4.5rem] shadow-md object-cover w-[400px] max-h-[420px] md:w-[480px] md:max-h-none"
-      src="/assets/profile.jpg"
-      alt="Myself in Daytona Beach, Florida"
-    />
+    <div class="relative">
+      <div class="absolute -inset-4 rounded-[3rem] bg-gradient-to-tr from-[#2f6bff]/20 via-white/10 to-[#f59e0b]/20 blur-2xl"></div>
+      <img
+        class="relative w-[420px] max-w-full rounded-[3rem] border border-white/60 bg-white/80 object-cover shadow-[0_20px_60px_rgba(15,23,42,0.2)]"
+        src="/assets/profile.jpg"
+        alt="Myself in Daytona Beach, Florida"
+      />
+    </div>
   </section>
 </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,15 +1,15 @@
 ---
 const currentPath = Astro.url.pathname
 const isActive = (path) => currentPath === path
-const baseLinkClasses = 'rounded-full px-[1rem] py-[0.5rem] font-semibold transition hover:-translate-y-0.5 hover:shadow-md'
-const activeLinkClasses = 'bg-[#0b0f1a] text-white'
-const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
+const baseLinkClasses = 'relative px-4 py-2 text-sm font-semibold transition'
+const activeLinkClasses = 'text-[#0c111f]'
+const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
 ---
 
 <nav
-  class="relative z-40 mx-auto mt-6 grid w-[min(92rem,92%)] items-center justify-between rounded-[2.5rem] border border-white/60 bg-white/75 px-6 py-4 shadow-[0_18px_40px_rgba(15,23,42,0.08)] backdrop-blur-xl md:grid-cols-[1fr,auto,1fr] md:px-10"
+  class="relative z-40 mx-auto mt-6 flex w-[min(92rem,92%)] items-center justify-between rounded-[1.75rem] border border-white/70 bg-white/70 px-6 py-4 shadow-[0_20px_40px_rgba(15,23,42,0.08)] backdrop-blur-xl"
 >
-  <div class="flex gap-2 items-center">
+  <div class="flex items-center gap-3">
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -50,9 +50,9 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
         <stop offset="0.5"></stop>
       </linearGradient>
     </svg>
-    <span class="font-semibold text-base tracking-wide md:text-xl"
-      >Johannes Drechsler</span
-    >
+    <span class="font-semibold text-base tracking-wide md:text-lg">
+      Johannes Drechsler
+    </span>
   </div>
   <details class="w-full select-none md:hidden">
     <summary
@@ -223,9 +223,7 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
       </ul>
     </div>
   </details>
-  <ul
-    class="hidden gap-3 rounded-full border border-white/60 bg-white/70 p-2 text-sm shadow-sm md:flex"
-  >
+  <ul class="hidden items-center gap-6 md:flex">
     <li
       class:list={[
         baseLinkClasses,
@@ -233,11 +231,14 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
       ]}
     >
       <a
-        class={isActive('/') ? 'hover:text-white' : 'hover:text-[#0b0f1a]'}
+        class="relative"
         href="/"
         aria-current={isActive('/') ? 'page' : undefined}
       >
         Home
+        {isActive('/') && (
+          <span class="absolute left-0 -bottom-2 h-1 w-full rounded-full bg-[#0c111f]"></span>
+        )}
       </a>
     </li>
     <li
@@ -247,11 +248,14 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
       ]}
     >
       <a
-        class={isActive('/work') ? 'hover:text-white' : 'hover:text-[#0b0f1a]'}
+        class="relative"
         href="/work"
         aria-current={isActive('/work') ? 'page' : undefined}
       >
         Work
+        {isActive('/work') && (
+          <span class="absolute left-0 -bottom-2 h-1 w-full rounded-full bg-[#0c111f]"></span>
+        )}
       </a>
     </li>
     <li
@@ -261,20 +265,30 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
       ]}
     >
       <a
-        class={isActive('/about') ? 'hover:text-white' : 'hover:text-[#0b0f1a]'}
+        class="relative"
         href="/about"
         aria-current={isActive('/about') ? 'page' : undefined}
       >
         About
+        {isActive('/about') && (
+          <span class="absolute left-0 -bottom-2 h-1 w-full rounded-full bg-[#0c111f]"></span>
+        )}
       </a>
     </li>
   </ul>
-  <ul class="hidden justify-end gap-2 md:flex">
-    <li>
+  <div class="hidden items-center gap-3 md:flex">
+    <a
+      href="mailto:JohannesDrechslerUS@gmail.com"
+      class="rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5"
+    >
+      Contact
+    </a>
+    <div class="flex items-center gap-2">
       <a
         href="https://github.com/JDrechsler"
-        class="transition-colors hover:text-white"
-        ><svg
+        class="rounded-full border border-white/60 bg-white/70 p-2 transition hover:-translate-y-0.5"
+        aria-label="GitHub"
+      ><svg
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -317,14 +331,13 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
               ></path>
             </g>
           </g></svg
-        ></a
-      >
-    </li>
-    <li>
+        ></svg>
+      </a>
       <a
         href="https://www.linkedin.com/in/jdrechslerus"
-        class="transition-colors hover:text-white"
-        ><svg
+        class="rounded-full border border-white/60 bg-white/70 p-2 transition hover:-translate-y-0.5"
+        aria-label="LinkedIn"
+      ><svg
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -352,14 +365,13 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
               d="M120 112v64m-32-64v64m32-36a28 28 0 0 1 56 0v36"></path>
             <circle stroke="none" cx="88" cy="80" r="12"></circle>
           </g></svg
-        ></a
-      >
-    </li>
-    <li>
+        ></svg>
+      </a>
       <a
         href="https://twitter.com/JDrechslerUS"
-        class="transition-colors hover:text-white"
-        ><svg
+        class="rounded-full border border-white/60 bg-white/70 p-2 transition hover:-translate-y-0.5"
+        aria-label="X (Twitter)"
+      ><svg
           xmlns="http://www.w3.org/2000/svg"
           width="24"
           height="24"
@@ -377,8 +389,8 @@ const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
               d="M128 88c0-22 18.5-40.3 40.5-40a40 40 0 0 1 36.2 24H240l-32.3 32.3A127.9 127.9 0 0 1 80 224c-32 0-40-12-40-12s32-12 48-36c0 0-64-32-48-120 0 0 40 40 88 48Z"
             ></path>
           </g></svg
-        ></a
-      >
-    </li>
-  </ul>
+        ></svg>
+      </a>
+    </div>
+  </div>
 </nav>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,3 +1,11 @@
+---
+const currentPath = Astro.url.pathname
+const isActive = (path) => currentPath === path
+const baseLinkClasses = 'rounded-full px-[1rem] py-[0.5rem] font-semibold transition hover:-translate-y-0.5 hover:shadow-md'
+const activeLinkClasses = 'bg-[#0b0f1a] text-white'
+const inactiveLinkClasses = 'bg-white text-[#0b0f1a]'
+---
+
 <nav
   class="relative z-40 mx-auto mt-6 grid w-[min(92rem,92%)] items-center justify-between rounded-[2.5rem] border border-white/60 bg-white/75 px-6 py-4 shadow-[0_18px_40px_rgba(15,23,42,0.08)] backdrop-blur-xl md:grid-cols-[1fr,auto,1fr] md:px-10"
 >
@@ -73,13 +81,31 @@
     >
       <ul class="flex flex-col gap-2 p-5">
         <li>
-          <a href="/" class="text-lg font-semibold text-[#0b0f1a]">Home</a>
+          <a
+            href="/"
+            class="text-lg font-semibold text-[#0b0f1a]"
+            aria-current={isActive('/') ? 'page' : undefined}
+          >
+            Home
+          </a>
         </li>
         <li>
-          <a href="/work" class="text-lg font-semibold text-[#0b0f1a]">Work</a>
+          <a
+            href="/work"
+            class="text-lg font-semibold text-[#0b0f1a]"
+            aria-current={isActive('/work') ? 'page' : undefined}
+          >
+            Work
+          </a>
         </li>
         <li>
-          <a href="/about" class="text-lg font-semibold text-[#0b0f1a]">About</a>
+          <a
+            href="/about"
+            class="text-lg font-semibold text-[#0b0f1a]"
+            aria-current={isActive('/about') ? 'page' : undefined}
+          >
+            About
+          </a>
         </li>
       </ul>
       <hr />
@@ -201,19 +227,46 @@
     class="hidden gap-3 rounded-full border border-white/60 bg-white/70 p-2 text-sm shadow-sm md:flex"
   >
     <li
-      class="rounded-full bg-[#0b0f1a] px-[1rem] py-[0.5rem] font-semibold text-white transition hover:-translate-y-0.5 hover:shadow-md"
+      class:list={[
+        baseLinkClasses,
+        isActive('/') ? activeLinkClasses : inactiveLinkClasses,
+      ]}
     >
-      <a class="hover:text-white" href="/">Home</a>
+      <a
+        class={isActive('/') ? 'hover:text-white' : 'hover:text-[#0b0f1a]'}
+        href="/"
+        aria-current={isActive('/') ? 'page' : undefined}
+      >
+        Home
+      </a>
     </li>
     <li
-      class="rounded-full bg-white px-[1rem] py-[0.5rem] font-semibold text-[#0b0f1a] transition hover:-translate-y-0.5 hover:shadow-md"
+      class:list={[
+        baseLinkClasses,
+        isActive('/work') ? activeLinkClasses : inactiveLinkClasses,
+      ]}
     >
-      <a class="hover:text-[#0b0f1a]" href="/work">Work</a>
+      <a
+        class={isActive('/work') ? 'hover:text-white' : 'hover:text-[#0b0f1a]'}
+        href="/work"
+        aria-current={isActive('/work') ? 'page' : undefined}
+      >
+        Work
+      </a>
     </li>
     <li
-      class="rounded-full bg-white px-[1rem] py-[0.5rem] font-semibold text-[#0b0f1a] transition hover:-translate-y-0.5 hover:shadow-md"
+      class:list={[
+        baseLinkClasses,
+        isActive('/about') ? activeLinkClasses : inactiveLinkClasses,
+      ]}
     >
-      <a class="hover:text-[#0b0f1a]" href="/about">About</a>
+      <a
+        class={isActive('/about') ? 'hover:text-white' : 'hover:text-[#0b0f1a]'}
+        href="/about"
+        aria-current={isActive('/about') ? 'page' : undefined}
+      >
+        About
+      </a>
     </li>
   </ul>
   <ul class="hidden justify-end gap-2 md:flex">

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,15 +1,18 @@
 ---
 const currentPath = Astro.url.pathname
 const isActive = (path) => currentPath === path
-const baseLinkClasses = 'relative px-4 py-2 text-sm font-semibold transition'
-const activeLinkClasses = 'text-[#0c111f]'
-const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
+const baseLinkClasses = 'px-4 py-2 text-sm font-semibold transition rounded-full'
+const activeLinkClasses = 'bg-white text-[#2f3447] shadow-sm'
+const inactiveLinkClasses = 'text-[#63657a] hover:text-[#2f3447]'
 ---
 
 <nav
-  class="relative z-40 mx-auto mt-6 flex w-[min(92rem,92%)] items-center justify-between rounded-[1.75rem] border border-white/70 bg-white/70 px-6 py-4 shadow-[0_20px_40px_rgba(15,23,42,0.08)] backdrop-blur-xl"
+  class="relative z-40 mx-auto mt-6 flex w-[min(92rem,92%)] items-center justify-between rounded-[2.5rem] border border-white/70 bg-white/65 px-6 py-4 shadow-[0_24px_48px_rgba(34,33,45,0.08)] backdrop-blur-xl"
 >
   <div class="flex items-center gap-3">
+    <div class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-[#f08a5d] to-[#f7b267] text-sm font-semibold text-white shadow-sm">
+      JD
+    </div>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="24"
@@ -50,7 +53,7 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         <stop offset="0.5"></stop>
       </linearGradient>
     </svg>
-    <span class="font-semibold text-base tracking-wide md:text-lg">
+    <span class="font-semibold text-base tracking-wide text-[#2f3447] md:text-lg">
       Johannes Drechsler
     </span>
   </div>
@@ -77,13 +80,16 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
       </svg>
     </summary>
     <div
-      class="absolute left-0 top-full z-50 mt-3 flex w-full flex-col rounded-2xl border border-white/60 bg-white/90 shadow-xl backdrop-blur-xl"
+      class="absolute left-0 top-full z-50 mt-3 flex w-full flex-col rounded-3xl border border-white/70 bg-white/90 shadow-xl backdrop-blur-xl"
     >
       <ul class="flex flex-col gap-2 p-5">
         <li>
           <a
             href="/"
-            class="text-lg font-semibold text-[#0b0f1a]"
+            class:list={[
+              'text-lg font-semibold rounded-full px-4 py-2',
+              isActive('/') ? 'bg-white text-[#2f3447] shadow-sm' : 'text-[#2f3447]'
+            ]}
             aria-current={isActive('/') ? 'page' : undefined}
           >
             Home
@@ -92,7 +98,10 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         <li>
           <a
             href="/work"
-            class="text-lg font-semibold text-[#0b0f1a]"
+            class:list={[
+              'text-lg font-semibold rounded-full px-4 py-2',
+              isActive('/work') ? 'bg-white text-[#2f3447] shadow-sm' : 'text-[#2f3447]'
+            ]}
             aria-current={isActive('/work') ? 'page' : undefined}
           >
             Work
@@ -101,7 +110,10 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         <li>
           <a
             href="/about"
-            class="text-lg font-semibold text-[#0b0f1a]"
+            class:list={[
+              'text-lg font-semibold rounded-full px-4 py-2',
+              isActive('/about') ? 'bg-white text-[#2f3447] shadow-sm' : 'text-[#2f3447]'
+            ]}
             aria-current={isActive('/about') ? 'page' : undefined}
           >
             About
@@ -113,7 +125,7 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         <li>
           <a
             href="https://github.com/JDrechsler"
-            class="transition-colors hover:text-gray-500"
+            class="rounded-full border border-white/70 bg-white/80 p-2 transition hover:-translate-y-0.5"
             ><svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -163,7 +175,7 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         <li>
           <a
             href="https://www.linkedin.com/in/jdrechslerus"
-            class="transition-colors hover:text-gray-500"
+            class="rounded-full border border-white/70 bg-white/80 p-2 transition hover:-translate-y-0.5"
             ><svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -198,7 +210,7 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         <li>
           <a
             href="https://twitter.com/JDrechslerUS"
-            class="transition-colors hover:text-gray-500"
+            class="rounded-full border border-white/70 bg-white/80 p-2 transition hover:-translate-y-0.5"
             ><svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -223,7 +235,7 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
       </ul>
     </div>
   </details>
-  <ul class="hidden items-center gap-6 md:flex">
+  <ul class="hidden items-center gap-2 rounded-full border border-white/70 bg-white/70 px-2 py-1 md:flex">
     <li
       class:list={[
         baseLinkClasses,
@@ -236,9 +248,6 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         aria-current={isActive('/') ? 'page' : undefined}
       >
         Home
-        {isActive('/') && (
-          <span class="absolute left-0 -bottom-2 h-1 w-full rounded-full bg-[#0c111f]"></span>
-        )}
       </a>
     </li>
     <li
@@ -253,9 +262,6 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         aria-current={isActive('/work') ? 'page' : undefined}
       >
         Work
-        {isActive('/work') && (
-          <span class="absolute left-0 -bottom-2 h-1 w-full rounded-full bg-[#0c111f]"></span>
-        )}
       </a>
     </li>
     <li
@@ -270,23 +276,20 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
         aria-current={isActive('/about') ? 'page' : undefined}
       >
         About
-        {isActive('/about') && (
-          <span class="absolute left-0 -bottom-2 h-1 w-full rounded-full bg-[#0c111f]"></span>
-        )}
       </a>
     </li>
   </ul>
   <div class="hidden items-center gap-3 md:flex">
     <a
       href="mailto:JohannesDrechslerUS@gmail.com"
-      class="rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5"
+      class="rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-semibold text-[#2f3447] shadow-sm transition hover:-translate-y-0.5"
     >
       Contact
     </a>
     <div class="flex items-center gap-2">
       <a
         href="https://github.com/JDrechsler"
-        class="rounded-full border border-white/60 bg-white/70 p-2 transition hover:-translate-y-0.5"
+        class="rounded-full border border-white/70 bg-white/70 p-2 transition hover:-translate-y-0.5"
         aria-label="GitHub"
       ><svg
           xmlns="http://www.w3.org/2000/svg"
@@ -335,7 +338,7 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
       </a>
       <a
         href="https://www.linkedin.com/in/jdrechslerus"
-        class="rounded-full border border-white/60 bg-white/70 p-2 transition hover:-translate-y-0.5"
+        class="rounded-full border border-white/70 bg-white/70 p-2 transition hover:-translate-y-0.5"
         aria-label="LinkedIn"
       ><svg
           xmlns="http://www.w3.org/2000/svg"
@@ -369,7 +372,7 @@ const inactiveLinkClasses = 'text-[#4a5162] hover:text-[#0c111f]'
       </a>
       <a
         href="https://twitter.com/JDrechslerUS"
-        class="rounded-full border border-white/60 bg-white/70 p-2 transition hover:-translate-y-0.5"
+        class="rounded-full border border-white/70 bg-white/70 p-2 transition hover:-translate-y-0.5"
         aria-label="X (Twitter)"
       ><svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Nav.html
+++ b/src/components/Nav.html
@@ -1,5 +1,5 @@
 <nav
-  class="relative grid items-center justify-between grid-flow-col p-[1.5rem] md:px-[5rem] md:py-[2.5rem] md:grid-cols-[1fr,auto,1fr] md:px-10 lg:px-24"
+  class="relative z-40 mx-auto mt-6 grid w-[min(92rem,92%)] items-center justify-between rounded-[2.5rem] border border-white/60 bg-white/75 px-6 py-4 shadow-[0_18px_40px_rgba(15,23,42,0.08)] backdrop-blur-xl md:grid-cols-[1fr,auto,1fr] md:px-10"
 >
   <div class="flex gap-2 items-center">
     <svg
@@ -48,7 +48,7 @@
   </div>
   <details class="w-full select-none md:hidden">
     <summary
-      class="list-none bg-gradient-to-r from-gray-200 to-gray-100 p-2 rounded-full shadow-sm hover:cursor-pointer hover:from-gray-300 hover:to-gray-200"
+      class="list-none rounded-full border border-white/60 bg-white/80 p-2 shadow-sm transition hover:cursor-pointer hover:bg-white"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -69,12 +69,18 @@
       </svg>
     </summary>
     <div
-      class="absolute z-50 bg-white left-0 top-full shadow-md rounded-b-lg w-full flex flex-col"
+      class="absolute left-0 top-full z-50 mt-3 flex w-full flex-col rounded-2xl border border-white/60 bg-white/90 shadow-xl backdrop-blur-xl"
     >
       <ul class="flex flex-col gap-2 p-5">
-        <li><a href="/" class="text-lg font-semibold">Home</a></li>
-        <li><a href="/work" class="text-lg font-semibold">Work</a></li>
-        <li><a href="/about" class="text-lg font-semibold">About</a></li>
+        <li>
+          <a href="/" class="text-lg font-semibold text-[#0b0f1a]">Home</a>
+        </li>
+        <li>
+          <a href="/work" class="text-lg font-semibold text-[#0b0f1a]">Work</a>
+        </li>
+        <li>
+          <a href="/about" class="text-lg font-semibold text-[#0b0f1a]">About</a>
+        </li>
       </ul>
       <hr />
       <ul class="flex justify-evenly gap-5 px-5 py-6">
@@ -192,22 +198,22 @@
     </div>
   </details>
   <ul
-    class="hidden bg-gray-100 shadow-md p-2 text-sm rounded-full gap-3 md:flex"
+    class="hidden gap-3 rounded-full border border-white/60 bg-white/70 p-2 text-sm shadow-sm md:flex"
   >
     <li
-      class="bg-accent text-white font-semibold px-[1rem] py-[0.5rem] rounded-full hover:opacity-80 hover:underline hover:underline-offset-4 hover:cursor-pointer"
+      class="rounded-full bg-[#0b0f1a] px-[1rem] py-[0.5rem] font-semibold text-white transition hover:-translate-y-0.5 hover:shadow-md"
     >
       <a class="hover:text-white" href="/">Home</a>
     </li>
     <li
-      class="bg-accent text-white font-semibold px-[1rem] py-[0.5rem] rounded-full hover:opacity-80 hover:underline hover:underline-offset-4 hover:cursor-pointer"
+      class="rounded-full bg-white px-[1rem] py-[0.5rem] font-semibold text-[#0b0f1a] transition hover:-translate-y-0.5 hover:shadow-md"
     >
-      <a class="hover:text-white" href="/work">Work</a>
+      <a class="hover:text-[#0b0f1a]" href="/work">Work</a>
     </li>
     <li
-      class="bg-accent text-white font-semibold px-[1rem] py-[0.5rem] rounded-full hover:opacity-80 hover:underline hover:underline-offset-4 hover:cursor-pointer"
+      class="rounded-full bg-white px-[1rem] py-[0.5rem] font-semibold text-[#0b0f1a] transition hover:-translate-y-0.5 hover:shadow-md"
     >
-      <a class="hover:text-white" href="/about">About</a>
+      <a class="hover:text-[#0b0f1a]" href="/about">About</a>
     </li>
   </ul>
   <ul class="hidden justify-end gap-2 md:flex">

--- a/src/components/Nav.html
+++ b/src/components/Nav.html
@@ -73,8 +73,8 @@
     >
       <ul class="flex flex-col gap-2 p-5">
         <li><a href="/" class="text-lg font-semibold">Home</a></li>
-        <li><a href="/" class="text-lg font-semibold">Work - WIP</a></li>
-        <li><a href="/about" class="text-lg font-semibold">About - WIP</a></li>
+        <li><a href="/work" class="text-lg font-semibold">Work</a></li>
+        <li><a href="/about" class="text-lg font-semibold">About</a></li>
       </ul>
       <hr />
       <ul class="flex justify-evenly gap-5 px-5 py-6">
@@ -202,12 +202,12 @@
     <li
       class="bg-accent text-white font-semibold px-[1rem] py-[0.5rem] rounded-full hover:opacity-80 hover:underline hover:underline-offset-4 hover:cursor-pointer"
     >
-      <a class="hover:text-white" href="/">Work - WIP</a>
+      <a class="hover:text-white" href="/work">Work</a>
     </li>
     <li
       class="bg-accent text-white font-semibold px-[1rem] py-[0.5rem] rounded-full hover:opacity-80 hover:underline hover:underline-offset-4 hover:cursor-pointer"
     >
-      <a class="hover:text-white" href="/about">About - WIP</a>
+      <a class="hover:text-white" href="/about">About</a>
     </li>
   </ul>
   <ul class="hidden justify-end gap-2 md:flex">

--- a/src/components/SoftSkills.html
+++ b/src/components/SoftSkills.html
@@ -1,9 +1,17 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
   <section class="lg:px-[2.5rem]">
-    <ul
-      class="grid gap-6 text-left md:grid-cols-3"
-    >
-      <li class="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_15px_40px_rgba(15,23,42,0.08)]">
+    <div class="rounded-[2.5rem] border border-white/70 bg-white/70 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+      <div class="flex flex-col gap-3 pb-6 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Strengths</p>
+          <h2 class="text-3xl font-semibold text-[#0c111f]">How I work</h2>
+        </div>
+        <p class="max-w-xl text-[#4a5162]">
+          A blend of strategy, performance discipline, and empathy for accessible, human-centered products.
+        </p>
+      </div>
+      <ul class="grid gap-6 md:grid-cols-3">
+        <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/80 p-6">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -51,10 +59,10 @@
             <stop offset="0.7"></stop>
           </linearGradient>
         </svg>
-        <p class="text-2xl font-semibold tracking-tight text-[#0b0f1a]">
+        <p class="text-2xl font-semibold tracking-tight text-[#0c111f]">
           Strategy-Minded
         </p>
-        <p class="text-[#3d4663] leading-relaxed">
+        <p class="text-[#4a5162] leading-relaxed">
           Throughout my extensive experience as a Full-Stack Software Engineer,
           I have worked with all the popular JS frameworks. I love JS but
           sometimes it is not necessary to use it. I am not a fan of using a
@@ -62,7 +70,7 @@
           the job.
         </p>
       </li>
-      <li class="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_15px_40px_rgba(15,23,42,0.08)]">
+      <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/80 p-6">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -89,10 +97,10 @@
             ></path>
           </g>
         </svg>
-        <p class="text-2xl font-semibold tracking-tight text-[#0b0f1a]">
+        <p class="text-2xl font-semibold tracking-tight text-[#0c111f]">
           Performance Oriented
         </p>
-        <p class="text-[#3d4663] leading-relaxed">
+        <p class="text-[#4a5162] leading-relaxed">
           I love performance. I imagine creating apps like painting a picture.
           Without friction or refreshes or losing focus. Instant previews and no
           wait. The current tooling system does not allow for such a workflow
@@ -101,7 +109,7 @@
           picture.
         </p>
       </li>
-      <li class="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_15px_40px_rgba(15,23,42,0.08)]">
+      <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/80 p-6">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -132,10 +140,10 @@
             ></rect>
           </g>
         </svg>
-        <p class="text-2xl font-semibold tracking-tight text-[#0b0f1a]">
+        <p class="text-2xl font-semibold tracking-tight text-[#0c111f]">
           Accessibility Focused
         </p>
-        <p class="text-[#3d4663] leading-relaxed">
+        <p class="text-[#4a5162] leading-relaxed">
           I did a 6-months Nanodegree with the Google Chrome engineers learning
           about the importance of accessibility and how to make websites
           accessible. I make sure that all my websites are accessible and user
@@ -143,5 +151,6 @@
         </p>
       </li>
     </ul>
+  </div>
   </section>
 </div>

--- a/src/components/SoftSkills.html
+++ b/src/components/SoftSkills.html
@@ -1,17 +1,17 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
   <section class="lg:px-[2.5rem]">
-    <div class="rounded-[2.5rem] border border-white/70 bg-white/70 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+    <div class="rounded-[2.5rem] border border-white/70 bg-white/80 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
       <div class="flex flex-col gap-3 pb-6 md:flex-row md:items-end md:justify-between">
         <div>
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Strengths</p>
-          <h2 class="text-3xl font-semibold text-[#0c111f]">How I work</h2>
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Strengths</p>
+          <h2 class="text-3xl font-semibold text-[#2f3447]">How I work</h2>
         </div>
-        <p class="max-w-xl text-[#4a5162]">
+        <p class="max-w-xl text-[#5f6577]">
           A blend of strategy, performance discipline, and empathy for accessible, human-centered products.
         </p>
       </div>
       <ul class="grid gap-6 md:grid-cols-3">
-        <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/80 p-6">
+        <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/90 p-6">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -59,10 +59,10 @@
             <stop offset="0.7"></stop>
           </linearGradient>
         </svg>
-        <p class="text-2xl font-semibold tracking-tight text-[#0c111f]">
+        <p class="text-2xl font-semibold tracking-tight text-[#2f3447]">
           Strategy-Minded
         </p>
-        <p class="text-[#4a5162] leading-relaxed">
+        <p class="text-[#5f6577] leading-relaxed">
           Throughout my extensive experience as a Full-Stack Software Engineer,
           I have worked with all the popular JS frameworks. I love JS but
           sometimes it is not necessary to use it. I am not a fan of using a
@@ -70,7 +70,7 @@
           the job.
         </p>
       </li>
-      <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/80 p-6">
+      <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/90 p-6">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -97,10 +97,10 @@
             ></path>
           </g>
         </svg>
-        <p class="text-2xl font-semibold tracking-tight text-[#0c111f]">
+        <p class="text-2xl font-semibold tracking-tight text-[#2f3447]">
           Performance Oriented
         </p>
-        <p class="text-[#4a5162] leading-relaxed">
+        <p class="text-[#5f6577] leading-relaxed">
           I love performance. I imagine creating apps like painting a picture.
           Without friction or refreshes or losing focus. Instant previews and no
           wait. The current tooling system does not allow for such a workflow
@@ -109,7 +109,7 @@
           picture.
         </p>
       </li>
-      <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/80 p-6">
+      <li class="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/90 p-6">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -140,10 +140,10 @@
             ></rect>
           </g>
         </svg>
-        <p class="text-2xl font-semibold tracking-tight text-[#0c111f]">
+        <p class="text-2xl font-semibold tracking-tight text-[#2f3447]">
           Accessibility Focused
         </p>
-        <p class="text-[#4a5162] leading-relaxed">
+        <p class="text-[#5f6577] leading-relaxed">
           I did a 6-months Nanodegree with the Google Chrome engineers learning
           about the importance of accessibility and how to make websites
           accessible. I make sure that all my websites are accessible and user

--- a/src/components/SoftSkills.html
+++ b/src/components/SoftSkills.html
@@ -1,9 +1,9 @@
 <div class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
   <section class="lg:px-[2.5rem]">
     <ul
-      class="grid grid-flow-row gap-y-10 gap-x-10 text-left shadow-md place-self-stretch p-6 rounded-xl border md:grid-flow-col xl:p-10"
+      class="grid gap-6 text-left md:grid-cols-3"
     >
-      <li class="flex flex-col gap-y-1 md:gap-y-4">
+      <li class="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_15px_40px_rgba(15,23,42,0.08)]">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -51,12 +51,10 @@
             <stop offset="0.7"></stop>
           </linearGradient>
         </svg>
-        <p
-          class="text-xl leading-[1.1] xl:text-3xl font-semibold tracking-wide"
-        >
+        <p class="text-2xl font-semibold tracking-tight text-[#0b0f1a]">
           Strategy-Minded
         </p>
-        <p class="text-[#3d4663]">
+        <p class="text-[#3d4663] leading-relaxed">
           Throughout my extensive experience as a Full-Stack Software Engineer,
           I have worked with all the popular JS frameworks. I love JS but
           sometimes it is not necessary to use it. I am not a fan of using a
@@ -64,7 +62,7 @@
           the job.
         </p>
       </li>
-      <li class="flex flex-col gap-y-1 md:gap-y-4">
+      <li class="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_15px_40px_rgba(15,23,42,0.08)]">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -91,12 +89,10 @@
             ></path>
           </g>
         </svg>
-        <p
-          class="text-xl leading-[1.1] xl:text-3xl font-semibold tracking-wide"
-        >
+        <p class="text-2xl font-semibold tracking-tight text-[#0b0f1a]">
           Performance Oriented
         </p>
-        <p class="text-[#3d4663]">
+        <p class="text-[#3d4663] leading-relaxed">
           I love performance. I imagine creating apps like painting a picture.
           Without friction or refreshes or losing focus. Instant previews and no
           wait. The current tooling system does not allow for such a workflow
@@ -105,7 +101,7 @@
           picture.
         </p>
       </li>
-      <li class="flex flex-col gap-y-1 md:gap-y-4">
+      <li class="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_15px_40px_rgba(15,23,42,0.08)]">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="40"
@@ -136,12 +132,10 @@
             ></rect>
           </g>
         </svg>
-        <p
-          class="text-xl xl:text-3xl font-semibold leading-[1.1] tracking-wide"
-        >
+        <p class="text-2xl font-semibold tracking-tight text-[#0b0f1a]">
           Accessibility Focused
         </p>
-        <p class="text-[#3d4663]">
+        <p class="text-[#3d4663] leading-relaxed">
           I did a 6-months Nanodegree with the Google Chrome engineers learning
           about the importance of accessibility and how to make websites
           accessible. I make sure that all my websites are accessible and user

--- a/src/components/WorkingTogether.html
+++ b/src/components/WorkingTogether.html
@@ -1,12 +1,18 @@
 <section
-  class="flex flex-col text-center justify-center items-center gap-8 border-y border-[#e3e6ee] shadow-md py-14 px-5 lg:flex-row lg:justify-evenly lg:py-36"
+  class="mx-auto w-[min(92rem,92%)] rounded-[2.5rem] border border-white/60 bg-gradient-to-br from-white/90 via-white/70 to-white/60 px-6 py-12 text-center shadow-[0_25px_60px_rgba(15,23,42,0.12)] backdrop-blur-xl lg:flex lg:items-center lg:justify-between lg:px-12 lg:py-16"
 >
-  <h2 class="text-2xl font-medium md:text-5xl">
-    Interested in working together?
-  </h2>
+  <div class="space-y-3">
+    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Let’s collaborate</p>
+    <h2 class="text-3xl font-semibold text-[#0b0f1a] md:text-5xl">
+      Interested in working together?
+    </h2>
+    <p class="text-[#3d4663] md:text-lg">
+      Reach out anytime — I’d love to hear about what you’re building.
+    </p>
+  </div>
   <a
     href="mailto:JohannesDrechslerUS@gmail.com"
-    class="bg-gradient-to-r from-accent via-accent to-gray-200 text-white px-5 py-2 text-lg rounded-3xl flex flex-wrap justify-center items-center gap-x-2 gap-y-1 items-center lg:text-2xl hover:from-accent hover:via-accent hover:to-accent hover:text-white transition-all duration-1000"
+    class="mt-6 inline-flex items-center justify-center gap-2 rounded-full bg-[#0b0f1a] px-6 py-3 text-base font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 lg:mt-0 lg:text-lg"
   >
     Send me a message
     <svg

--- a/src/components/WorkingTogether.html
+++ b/src/components/WorkingTogether.html
@@ -1,19 +1,19 @@
 <section
-  class="mx-auto w-[min(92rem,92%)] rounded-[2.75rem] border border-white/70 bg-white/80 px-6 py-12 shadow-[0_30px_70px_rgba(15,23,42,0.12)] backdrop-blur-xl lg:flex lg:items-center lg:justify-between lg:px-12 lg:py-16"
+  class="mx-auto w-[min(92rem,92%)] rounded-[2.75rem] border border-white/70 bg-white/85 px-6 py-12 shadow-[0_30px_70px_rgba(45,42,36,0.12)] backdrop-blur-xl lg:flex lg:items-center lg:justify-between lg:px-12 lg:py-16"
 >
   <div class="space-y-4 text-left">
-    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Let’s collaborate</p>
-    <h2 class="text-3xl font-semibold text-[#0c111f] md:text-5xl">
+    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Let’s collaborate</p>
+    <h2 class="text-3xl font-semibold text-[#2f3447] md:text-5xl">
       Interested in building something together?
     </h2>
-    <p class="text-[#4a5162] md:text-lg">
+    <p class="text-[#5f6577] md:text-lg">
       Reach out anytime — I’d love to hear about what you’re building.
     </p>
   </div>
   <div class="mt-6 flex flex-wrap items-center gap-4 lg:mt-0">
     <a
       href="mailto:JohannesDrechslerUS@gmail.com"
-      class="inline-flex items-center justify-center gap-2 rounded-full bg-[#0c111f] px-6 py-3 text-base font-semibold text-white shadow-[0_12px_30px_rgba(12,17,31,0.2)] transition hover:-translate-y-0.5 lg:text-lg"
+      class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#f08a5d] to-[#f7b267] px-6 py-3 text-base font-semibold text-white shadow-[0_12px_30px_rgba(240,138,93,0.3)] transition hover:-translate-y-0.5 lg:text-lg"
     >
       Send me a message
       <svg
@@ -38,7 +38,7 @@
     </a>
     <a
       href="https://www.linkedin.com/in/jdrechslerus"
-      class="inline-flex items-center justify-center gap-2 rounded-full border border-white/70 bg-white/90 px-6 py-3 text-base font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5 lg:text-lg"
+      class="inline-flex items-center justify-center gap-2 rounded-full border border-white/70 bg-white/95 px-6 py-3 text-base font-semibold text-[#2f3447] shadow-sm transition hover:-translate-y-0.5 lg:text-lg"
     >
       LinkedIn
     </a>

--- a/src/components/WorkingTogether.html
+++ b/src/components/WorkingTogether.html
@@ -1,38 +1,46 @@
 <section
-  class="mx-auto w-[min(92rem,92%)] rounded-[2.5rem] border border-white/60 bg-gradient-to-br from-white/90 via-white/70 to-white/60 px-6 py-12 text-center shadow-[0_25px_60px_rgba(15,23,42,0.12)] backdrop-blur-xl lg:flex lg:items-center lg:justify-between lg:px-12 lg:py-16"
+  class="mx-auto w-[min(92rem,92%)] rounded-[2.75rem] border border-white/70 bg-white/80 px-6 py-12 shadow-[0_30px_70px_rgba(15,23,42,0.12)] backdrop-blur-xl lg:flex lg:items-center lg:justify-between lg:px-12 lg:py-16"
 >
-  <div class="space-y-3">
-    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Let’s collaborate</p>
-    <h2 class="text-3xl font-semibold text-[#0b0f1a] md:text-5xl">
-      Interested in working together?
+  <div class="space-y-4 text-left">
+    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Let’s collaborate</p>
+    <h2 class="text-3xl font-semibold text-[#0c111f] md:text-5xl">
+      Interested in building something together?
     </h2>
-    <p class="text-[#3d4663] md:text-lg">
+    <p class="text-[#4a5162] md:text-lg">
       Reach out anytime — I’d love to hear about what you’re building.
     </p>
   </div>
-  <a
-    href="mailto:JohannesDrechslerUS@gmail.com"
-    class="mt-6 inline-flex items-center justify-center gap-2 rounded-full bg-[#0b0f1a] px-6 py-3 text-base font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 lg:mt-0 lg:text-lg"
-  >
-    Send me a message
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="20"
-      height="20"
-      viewBox="0 0 256 256"
-      aria-hidden="true"
-      stroke="currentcolor"
-      fill="currentcolor"
+  <div class="mt-6 flex flex-wrap items-center gap-4 lg:mt-0">
+    <a
+      href="mailto:JohannesDrechslerUS@gmail.com"
+      class="inline-flex items-center justify-center gap-2 rounded-full bg-[#0c111f] px-6 py-3 text-base font-semibold text-white shadow-[0_12px_30px_rgba(12,17,31,0.2)] transition hover:-translate-y-0.5 lg:text-lg"
     >
-      <g>
-        <path
-          fill="none"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          d="M210.3 35.9 23.9 88.4a8 8 0 0 0-1.2 15l85.6 40.5a7.8 7.8 0 0 1 3.8 3.8l40.5 85.6a8 8 0 0 0 15-1.2l52.5-186.4a7.9 7.9 0 0 0-9.8-9.8Zm-99.4 109.2 45.2-45.2"
-        ></path>
-      </g>
-    </svg>
-  </a>
+      Send me a message
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 256 256"
+        aria-hidden="true"
+        stroke="currentcolor"
+        fill="currentcolor"
+      >
+        <g>
+          <path
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            d="M210.3 35.9 23.9 88.4a8 8 0 0 0-1.2 15l85.6 40.5a7.8 7.8 0 0 1 3.8 3.8l40.5 85.6a8 8 0 0 0 15-1.2l52.5-186.4a7.9 7.9 0 0 0-9.8-9.8Zm-99.4 109.2 45.2-45.2"
+          ></path>
+        </g>
+      </svg>
+    </a>
+    <a
+      href="https://www.linkedin.com/in/jdrechslerus"
+      class="inline-flex items-center justify-center gap-2 rounded-full border border-white/70 bg-white/90 px-6 py-3 text-base font-semibold text-[#0c111f] shadow-sm transition hover:-translate-y-0.5 lg:text-lg"
+    >
+      LinkedIn
+    </a>
+  </div>
 </section>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const { title } = Astro.props
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.ico" />
     <title>{title}</title>
   </head>
-  <body class="p-0 m-0 background text-[#0c111f]">
+  <body class="p-0 m-0 background text-[#2f3447]">
     <Nav />
     <slot />
     <Footer />
@@ -30,23 +30,23 @@ const { title } = Astro.props
 </html>
 <style is:global>
   .background {
-    background-color: #f3f4f8;
+    background-color: #fbf6ef;
     background-image: radial-gradient(
-        90rem 40rem at 15% -10%,
-        rgba(38, 98, 255, 0.18),
+        60rem 30rem at 20% -10%,
+        rgba(255, 210, 182, 0.55),
         transparent 60%
       ),
       radial-gradient(
-        60rem 30rem at 95% 15%,
-        rgba(255, 140, 120, 0.18),
-        transparent 55%
+        60rem 34rem at 90% 15%,
+        rgba(255, 199, 160, 0.35),
+        transparent 60%
       ),
       radial-gradient(
-        50rem 26rem at 20% 90%,
-        rgba(80, 201, 170, 0.16),
-        transparent 55%
+        48rem 28rem at 70% 75%,
+        rgba(255, 224, 196, 0.4),
+        transparent 60%
       ),
-      linear-gradient(180deg, #f7f8fc 0%, #eef0f6 55%, #f7f8fc 100%);
+      linear-gradient(180deg, #fdf9f4 0%, #f7f1e9 65%, #fdf9f4 100%);
     background-attachment: fixed;
   }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const { title } = Astro.props
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.ico" />
     <title>{title}</title>
   </head>
-  <body class="p-0 m-0 background">
+  <body class="p-0 m-0 background text-[#0b0f1a]">
     <Nav />
     <slot />
     <Footer />
@@ -30,11 +30,23 @@ const { title } = Astro.props
 </html>
 <style is:global>
   .background {
-    background-image: url('/assets/bg.svg');
-    background-size: contain;
-    background-position: top;
-    background-repeat: no-repeat;
-    background-attachment: scroll;
-    backdrop-filter: blur(50px);
+    background-color: #f5f6fb;
+    background-image: radial-gradient(
+        circle at top,
+        rgba(87, 128, 255, 0.16),
+        transparent 55%
+      ),
+      radial-gradient(
+        circle at 20% 20%,
+        rgba(150, 176, 187, 0.25),
+        transparent 40%
+      ),
+      radial-gradient(
+        circle at 90% 10%,
+        rgba(255, 191, 105, 0.2),
+        transparent 45%
+      ),
+      linear-gradient(180deg, #f5f6fb 0%, #eef1f6 60%, #f5f6fb 100%);
+    background-attachment: fixed;
   }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const { title } = Astro.props
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.ico" />
     <title>{title}</title>
   </head>
-  <body class="p-0 m-0 background text-[#0b0f1a]">
+  <body class="p-0 m-0 background text-[#0c111f]">
     <Nav />
     <slot />
     <Footer />
@@ -30,23 +30,23 @@ const { title } = Astro.props
 </html>
 <style is:global>
   .background {
-    background-color: #f5f6fb;
+    background-color: #f3f4f8;
     background-image: radial-gradient(
-        circle at top,
-        rgba(87, 128, 255, 0.16),
+        90rem 40rem at 15% -10%,
+        rgba(38, 98, 255, 0.18),
+        transparent 60%
+      ),
+      radial-gradient(
+        60rem 30rem at 95% 15%,
+        rgba(255, 140, 120, 0.18),
         transparent 55%
       ),
       radial-gradient(
-        circle at 20% 20%,
-        rgba(150, 176, 187, 0.25),
-        transparent 40%
+        50rem 26rem at 20% 90%,
+        rgba(80, 201, 170, 0.16),
+        transparent 55%
       ),
-      radial-gradient(
-        circle at 90% 10%,
-        rgba(255, 191, 105, 0.2),
-        transparent 45%
-      ),
-      linear-gradient(180deg, #f5f6fb 0%, #eef1f6 60%, #f5f6fb 100%);
+      linear-gradient(180deg, #f7f8fc 0%, #eef0f6 55%, #f7f8fc 100%);
     background-attachment: fixed;
   }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import Nav from '../components/Nav.html'
+import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 import '../styles/global.css'
 

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -8,28 +8,28 @@ import WorkingTogether from '../components/WorkingTogether.html'
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-12 items-center lg:grid-cols-[1.1fr,0.9fr]">
         <div class="space-y-6">
-          <p class="text-sm font-semibold uppercase tracking-[0.4em] text-[#2f6bff]">Selected work</p>
-          <h1 class="text-[42px] font-semibold tracking-tight text-[#0b0f1a] md:text-7xl">
-            Building web experiences that feel effortless.
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Selected work</p>
+          <h1 class="text-[42px] font-semibold tracking-tight text-[#0c111f] md:text-7xl">
+            Crafting web experiences that stay elegant at scale.
           </h1>
-          <p class="text-lg text-[#3d4663] md:text-[22px] md:leading-[36px]">
+          <p class="text-lg text-[#4a5162] md:text-[22px] md:leading-[36px]">
             I help teams ship modern, accessible products with high performance, thoughtful UX, and sustainable
             engineering practices. Here are a few focus areas and highlights from recent years.
           </p>
         </div>
         <div class="grid gap-4">
-          <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
-            <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Specialties</p>
-            <ul class="mt-4 space-y-2 text-[#3d4663]">
+          <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+            <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Specialties</p>
+            <ul class="mt-4 space-y-2 text-[#4a5162]">
               <li>• JavaScript / TypeScript ecosystems</li>
               <li>• React, Angular, and modern web frameworks</li>
               <li>• Performance, accessibility, and design systems</li>
               <li>• Team leadership and mentoring</li>
             </ul>
           </div>
-          <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
-            <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Impact</p>
-            <p class="mt-4 text-[#3d4663]">
+          <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+            <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Impact</p>
+            <p class="mt-4 text-[#4a5162]">
               Delivered Lighthouse score improvements up to 97–100, created new testing pipelines, and led teams
               building customer-facing platforms at scale.
             </p>
@@ -39,31 +39,31 @@ import WorkingTogether from '../components/WorkingTogether.html'
     </section>
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
-      <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
+      <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
         <div class="space-y-2">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Featured</p>
-          <h2 class="text-3xl font-semibold text-[#0b0f1a]">Developer Tooling</h2>
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Featured</p>
+          <h2 class="text-3xl font-semibold text-[#0c111f]">Developer Tooling</h2>
         </div>
         <div class="space-y-6">
-          <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
-            <h3 class="font-semibold text-xl text-[#0b0f1a]">Next-gen HMR + React Fast Refresh</h3>
-            <p class="mt-3 text-[#3d4663]">
+          <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
+            <h3 class="font-semibold text-xl text-[#0c111f]">Next-gen HMR + React Fast Refresh</h3>
+            <p class="mt-3 text-[#4a5162]">
               Building a workflow that lets developers focus on specific components and iterate without losing state
               or context. The goal is a seamless, fluid development experience that removes delays and distractions.
             </p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
-            <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
-              <p class="font-semibold text-[#0b0f1a]">Key Outcomes</p>
-              <ul class="mt-2 list-disc list-inside space-y-1 text-[#3d4663]">
+            <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
+              <p class="font-semibold text-[#0c111f]">Key Outcomes</p>
+              <ul class="mt-2 list-disc list-inside space-y-1 text-[#4a5162]">
                 <li>Component-focused previews</li>
                 <li>State-preserving hot reload</li>
                 <li>Immediate feedback loops</li>
               </ul>
             </div>
-            <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
-              <p class="font-semibold text-[#0b0f1a]">Status</p>
-              <p class="mt-2 text-[#3d4663]">
+            <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
+              <p class="font-semibold text-[#0c111f]">Status</p>
+              <p class="mt-2 text-[#4a5162]">
                 Actively prototyping and validating workflows with modern web stacks.
               </p>
             </div>
@@ -74,19 +74,19 @@ import WorkingTogether from '../components/WorkingTogether.html'
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-6 md:grid-cols-2">
-        <div class="rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">BMW Group</p>
-          <h2 class="mt-3 text-2xl font-semibold text-[#0b0f1a]">Smart Mobility Platforms</h2>
-          <ul class="mt-4 list-disc list-inside space-y-2 text-[#3d4663]">
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">BMW Group</p>
+          <h2 class="mt-3 text-2xl font-semibold text-[#0c111f]">Smart Mobility Platforms</h2>
+          <ul class="mt-4 list-disc list-inside space-y-2 text-[#4a5162]">
             <li>Led Gatsby + React marketing site from scratch.</li>
             <li>Improved Lighthouse performance from 45% to 97% and accessibility to 100%.</li>
             <li>Delivered Angular 10 smart charging and Angular 12 + NestJS smart ticket platform.</li>
           </ul>
         </div>
-        <div class="rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Engineering Leadership</p>
-          <h2 class="mt-3 text-2xl font-semibold text-[#0b0f1a]">Testing & Delivery</h2>
-          <ul class="mt-4 list-disc list-inside space-y-2 text-[#3d4663]">
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Engineering Leadership</p>
+          <h2 class="mt-3 text-2xl font-semibold text-[#0c111f]">Testing & Delivery</h2>
+          <ul class="mt-4 list-disc list-inside space-y-2 text-[#4a5162]">
             <li>Built TypeScript testing pipeline with TestCafe, Jenkins, and Jira reporting.</li>
             <li>Mentored and coached teams through design and code review cycles.</li>
             <li>Improved performance for enterprise platforms across global clients.</li>
@@ -97,17 +97,17 @@ import WorkingTogether from '../components/WorkingTogether.html'
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-6 md:grid-cols-3">
-        <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
-          <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Industries</p>
-          <p class="mt-4 text-[#3d4663]">Automotive, healthcare, retail, developer tooling, and smart mobility.</p>
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Industries</p>
+          <p class="mt-4 text-[#4a5162]">Automotive, healthcare, retail, developer tooling, and smart mobility.</p>
         </div>
-        <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
-          <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Strengths</p>
-          <p class="mt-4 text-[#3d4663]">Performance optimization, accessibility excellence, and scalable frontend architecture.</p>
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Strengths</p>
+          <p class="mt-4 text-[#4a5162]">Performance optimization, accessibility excellence, and scalable frontend architecture.</p>
         </div>
-        <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
-          <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Location</p>
-          <p class="mt-4 text-[#3d4663]">Based in Valencia, Spain with 7 years of US experience.</p>
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Location</p>
+          <p class="mt-4 text-[#4a5162]">Based in Valencia, Spain with 7 years of US experience.</p>
         </div>
       </div>
     </section>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -1,0 +1,117 @@
+---
+import Layout from '../layouts/Layout.astro'
+import WorkingTogether from '../components/WorkingTogether.html'
+---
+
+<Layout title="Johannes Drechsler: Work">
+  <main class="flex flex-col gap-16 py-16 md:py-24">
+    <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
+      <div class="grid gap-10 items-center lg:grid-cols-[1.1fr,0.9fr]">
+        <div class="space-y-6">
+          <p class="text-accent font-medium tracking-wide">SELECTED WORK</p>
+          <h1 class="text-[42px] text-[#090b11] font-bold tracking-wider leading-[1.1] md:text-7xl bg-gradient-to-r from-[#090b11] via-accent to-[#090b11] bg-clip-text text-transparent">
+            Building web experiences that feel effortless.
+          </h1>
+          <p class="text-xl text-[#3d4663] !leading-[39px] md:text-[26px]">
+            I help teams ship modern, accessible products with high performance, thoughtful UX, and sustainable
+            engineering practices. Here are a few focus areas and highlights from recent years.
+          </p>
+        </div>
+        <div class="grid gap-4">
+          <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
+            <p class="text-sm text-gray-500 uppercase tracking-wide">Specialties</p>
+            <ul class="mt-3 space-y-2 text-[#3d4663]">
+              <li>• JavaScript / TypeScript ecosystems</li>
+              <li>• React, Angular, and modern web frameworks</li>
+              <li>• Performance, accessibility, and design systems</li>
+              <li>• Team leadership and mentoring</li>
+            </ul>
+          </div>
+          <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
+            <p class="text-sm text-gray-500 uppercase tracking-wide">Impact</p>
+            <p class="mt-3 text-[#3d4663]">
+              Delivered Lighthouse score improvements up to 97–100, created new testing pipelines, and led teams
+              building customer-facing platforms at scale.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
+      <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
+        <div class="space-y-2">
+          <p class="text-accent font-medium tracking-wide">FEATURED</p>
+          <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Developer Tooling</h2>
+        </div>
+        <div class="space-y-6">
+          <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+            <h3 class="font-semibold text-xl text-[#090b11]">Next-gen HMR + React Fast Refresh</h3>
+            <p class="mt-3 text-gray-600">
+              Building a workflow that lets developers focus on specific components and iterate without losing state
+              or context. The goal is a seamless, fluid development experience that removes delays and distractions.
+            </p>
+          </div>
+          <div class="grid gap-4 md:grid-cols-2">
+            <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+              <p class="font-semibold text-[#090b11]">Key Outcomes</p>
+              <ul class="mt-2 text-gray-600 list-disc list-inside space-y-1">
+                <li>Component-focused previews</li>
+                <li>State-preserving hot reload</li>
+                <li>Immediate feedback loops</li>
+              </ul>
+            </div>
+            <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
+              <p class="font-semibold text-[#090b11]">Status</p>
+              <p class="mt-2 text-gray-600">
+                Actively prototyping and validating workflows with modern web stacks.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
+      <div class="grid gap-6 md:grid-cols-2">
+        <div class="p-8 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
+          <p class="text-accent font-medium tracking-wide">BMW GROUP</p>
+          <h2 class="text-2xl font-semibold text-[#090b11] mt-2">Smart Mobility Platforms</h2>
+          <ul class="mt-4 text-[#3d4663] space-y-2 list-disc list-inside">
+            <li>Led Gatsby + React marketing site from scratch.</li>
+            <li>Improved Lighthouse performance from 45% to 97% and accessibility to 100%.</li>
+            <li>Delivered Angular 10 smart charging and Angular 12 + NestJS smart ticket platform.</li>
+          </ul>
+        </div>
+        <div class="p-8 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
+          <p class="text-accent font-medium tracking-wide">ENGINEERING LEADERSHIP</p>
+          <h2 class="text-2xl font-semibold text-[#090b11] mt-2">Testing & Delivery</h2>
+          <ul class="mt-4 text-[#3d4663] space-y-2 list-disc list-inside">
+            <li>Built TypeScript testing pipeline with TestCafe, Jenkins, and Jira reporting.</li>
+            <li>Mentored and coached teams through design and code review cycles.</li>
+            <li>Improved performance for enterprise platforms across global clients.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
+      <div class="grid gap-6 md:grid-cols-3">
+        <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
+          <p class="text-sm text-gray-500 uppercase tracking-wide">Industries</p>
+          <p class="mt-3 text-[#3d4663]">Automotive, healthcare, retail, developer tooling, and smart mobility.</p>
+        </div>
+        <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
+          <p class="text-sm text-gray-500 uppercase tracking-wide">Strengths</p>
+          <p class="mt-3 text-[#3d4663]">Performance optimization, accessibility excellence, and scalable frontend architecture.</p>
+        </div>
+        <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
+          <p class="text-sm text-gray-500 uppercase tracking-wide">Location</p>
+          <p class="mt-3 text-[#3d4663]">Based in Valencia, Spain with 7 years of US experience.</p>
+        </div>
+      </div>
+    </section>
+
+    <WorkingTogether />
+  </main>
+</Layout>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -6,30 +6,30 @@ import WorkingTogether from '../components/WorkingTogether.html'
 <Layout title="Johannes Drechsler: Work">
   <main class="flex flex-col gap-16 py-16 md:py-24">
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
-      <div class="grid gap-10 items-center lg:grid-cols-[1.1fr,0.9fr]">
+      <div class="grid gap-12 items-center lg:grid-cols-[1.1fr,0.9fr]">
         <div class="space-y-6">
-          <p class="text-accent font-medium tracking-wide">SELECTED WORK</p>
-          <h1 class="text-[42px] text-[#090b11] font-bold tracking-wider leading-[1.1] md:text-7xl bg-gradient-to-r from-[#090b11] via-accent to-[#090b11] bg-clip-text text-transparent">
+          <p class="text-sm font-semibold uppercase tracking-[0.4em] text-[#2f6bff]">Selected work</p>
+          <h1 class="text-[42px] font-semibold tracking-tight text-[#0b0f1a] md:text-7xl">
             Building web experiences that feel effortless.
           </h1>
-          <p class="text-xl text-[#3d4663] !leading-[39px] md:text-[26px]">
+          <p class="text-lg text-[#3d4663] md:text-[22px] md:leading-[36px]">
             I help teams ship modern, accessible products with high performance, thoughtful UX, and sustainable
             engineering practices. Here are a few focus areas and highlights from recent years.
           </p>
         </div>
         <div class="grid gap-4">
-          <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
-            <p class="text-sm text-gray-500 uppercase tracking-wide">Specialties</p>
-            <ul class="mt-3 space-y-2 text-[#3d4663]">
+          <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+            <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Specialties</p>
+            <ul class="mt-4 space-y-2 text-[#3d4663]">
               <li>• JavaScript / TypeScript ecosystems</li>
               <li>• React, Angular, and modern web frameworks</li>
               <li>• Performance, accessibility, and design systems</li>
               <li>• Team leadership and mentoring</li>
             </ul>
           </div>
-          <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
-            <p class="text-sm text-gray-500 uppercase tracking-wide">Impact</p>
-            <p class="mt-3 text-[#3d4663]">
+          <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+            <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Impact</p>
+            <p class="mt-4 text-[#3d4663]">
               Delivered Lighthouse score improvements up to 97–100, created new testing pipelines, and led teams
               building customer-facing platforms at scale.
             </p>
@@ -39,31 +39,31 @@ import WorkingTogether from '../components/WorkingTogether.html'
     </section>
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
-      <div class="grid gap-8 items-start lg:grid-cols-[250px,1fr] bg-white/80 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-gray-100">
+      <div class="grid gap-8 items-start rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)] lg:grid-cols-[250px,1fr]">
         <div class="space-y-2">
-          <p class="text-accent font-medium tracking-wide">FEATURED</p>
-          <h2 class="text-3xl text-[#090b11] font-bold bg-gradient-to-r from-[#090b11] to-accent bg-clip-text text-transparent">Developer Tooling</h2>
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Featured</p>
+          <h2 class="text-3xl font-semibold text-[#0b0f1a]">Developer Tooling</h2>
         </div>
         <div class="space-y-6">
-          <div class="p-6 rounded-xl bg-gray-50/80 backdrop-blur-sm">
-            <h3 class="font-semibold text-xl text-[#090b11]">Next-gen HMR + React Fast Refresh</h3>
-            <p class="mt-3 text-gray-600">
+          <div class="rounded-2xl border border-white/60 bg-white/70 p-6">
+            <h3 class="font-semibold text-xl text-[#0b0f1a]">Next-gen HMR + React Fast Refresh</h3>
+            <p class="mt-3 text-[#3d4663]">
               Building a workflow that lets developers focus on specific components and iterate without losing state
               or context. The goal is a seamless, fluid development experience that removes delays and distractions.
             </p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
-            <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
-              <p class="font-semibold text-[#090b11]">Key Outcomes</p>
-              <ul class="mt-2 text-gray-600 list-disc list-inside space-y-1">
+            <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
+              <p class="font-semibold text-[#0b0f1a]">Key Outcomes</p>
+              <ul class="mt-2 list-disc list-inside space-y-1 text-[#3d4663]">
                 <li>Component-focused previews</li>
                 <li>State-preserving hot reload</li>
                 <li>Immediate feedback loops</li>
               </ul>
             </div>
-            <div class="p-5 rounded-xl bg-gray-50/80 backdrop-blur-sm">
-              <p class="font-semibold text-[#090b11]">Status</p>
-              <p class="mt-2 text-gray-600">
+            <div class="rounded-2xl border border-white/60 bg-white/70 p-5">
+              <p class="font-semibold text-[#0b0f1a]">Status</p>
+              <p class="mt-2 text-[#3d4663]">
                 Actively prototyping and validating workflows with modern web stacks.
               </p>
             </div>
@@ -74,19 +74,19 @@ import WorkingTogether from '../components/WorkingTogether.html'
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-6 md:grid-cols-2">
-        <div class="p-8 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
-          <p class="text-accent font-medium tracking-wide">BMW GROUP</p>
-          <h2 class="text-2xl font-semibold text-[#090b11] mt-2">Smart Mobility Platforms</h2>
-          <ul class="mt-4 text-[#3d4663] space-y-2 list-disc list-inside">
+        <div class="rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">BMW Group</p>
+          <h2 class="mt-3 text-2xl font-semibold text-[#0b0f1a]">Smart Mobility Platforms</h2>
+          <ul class="mt-4 list-disc list-inside space-y-2 text-[#3d4663]">
             <li>Led Gatsby + React marketing site from scratch.</li>
             <li>Improved Lighthouse performance from 45% to 97% and accessibility to 100%.</li>
             <li>Delivered Angular 10 smart charging and Angular 12 + NestJS smart ticket platform.</li>
           </ul>
         </div>
-        <div class="p-8 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
-          <p class="text-accent font-medium tracking-wide">ENGINEERING LEADERSHIP</p>
-          <h2 class="text-2xl font-semibold text-[#090b11] mt-2">Testing & Delivery</h2>
-          <ul class="mt-4 text-[#3d4663] space-y-2 list-disc list-inside">
+        <div class="rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2f6bff]">Engineering Leadership</p>
+          <h2 class="mt-3 text-2xl font-semibold text-[#0b0f1a]">Testing & Delivery</h2>
+          <ul class="mt-4 list-disc list-inside space-y-2 text-[#3d4663]">
             <li>Built TypeScript testing pipeline with TestCafe, Jenkins, and Jira reporting.</li>
             <li>Mentored and coached teams through design and code review cycles.</li>
             <li>Improved performance for enterprise platforms across global clients.</li>
@@ -97,17 +97,17 @@ import WorkingTogether from '../components/WorkingTogether.html'
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-6 md:grid-cols-3">
-        <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
-          <p class="text-sm text-gray-500 uppercase tracking-wide">Industries</p>
-          <p class="mt-3 text-[#3d4663]">Automotive, healthcare, retail, developer tooling, and smart mobility.</p>
+        <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Industries</p>
+          <p class="mt-4 text-[#3d4663]">Automotive, healthcare, retail, developer tooling, and smart mobility.</p>
         </div>
-        <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
-          <p class="text-sm text-gray-500 uppercase tracking-wide">Strengths</p>
-          <p class="mt-3 text-[#3d4663]">Performance optimization, accessibility excellence, and scalable frontend architecture.</p>
+        <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Strengths</p>
+          <p class="mt-4 text-[#3d4663]">Performance optimization, accessibility excellence, and scalable frontend architecture.</p>
         </div>
-        <div class="p-6 rounded-2xl bg-white/80 backdrop-blur-sm shadow-lg border border-gray-100">
-          <p class="text-sm text-gray-500 uppercase tracking-wide">Location</p>
-          <p class="mt-3 text-[#3d4663]">Based in Valencia, Spain with 7 years of US experience.</p>
+        <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#6474a2]">Location</p>
+          <p class="mt-4 text-[#3d4663]">Based in Valencia, Spain with 7 years of US experience.</p>
         </div>
       </div>
     </section>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -8,28 +8,28 @@ import WorkingTogether from '../components/WorkingTogether.html'
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-12 items-center lg:grid-cols-[1.1fr,0.9fr]">
         <div class="space-y-6">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Selected work</p>
-          <h1 class="text-[42px] font-semibold tracking-tight text-[#0c111f] md:text-7xl">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Selected work</p>
+          <h1 class="text-[42px] font-semibold tracking-tight text-[#2f3447] md:text-7xl">
             Crafting web experiences that stay elegant at scale.
           </h1>
-          <p class="text-lg text-[#4a5162] md:text-[22px] md:leading-[36px]">
+          <p class="text-lg text-[#5f6577] md:text-[22px] md:leading-[36px]">
             I help teams ship modern, accessible products with high performance, thoughtful UX, and sustainable
             engineering practices. Here are a few focus areas and highlights from recent years.
           </p>
         </div>
         <div class="grid gap-4">
-          <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
-            <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Specialties</p>
-            <ul class="mt-4 space-y-2 text-[#4a5162]">
+          <div class="rounded-[2.5rem] border border-white/70 bg-white/85 p-6 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
+            <p class="text-sm uppercase tracking-[0.25em] text-[#a3988f]">Specialties</p>
+            <ul class="mt-4 space-y-2 text-[#5f6577]">
               <li>• JavaScript / TypeScript ecosystems</li>
               <li>• React, Angular, and modern web frameworks</li>
               <li>• Performance, accessibility, and design systems</li>
               <li>• Team leadership and mentoring</li>
             </ul>
           </div>
-          <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
-            <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Impact</p>
-            <p class="mt-4 text-[#4a5162]">
+          <div class="rounded-[2.5rem] border border-white/70 bg-white/85 p-6 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
+            <p class="text-sm uppercase tracking-[0.25em] text-[#a3988f]">Impact</p>
+            <p class="mt-4 text-[#5f6577]">
               Delivered Lighthouse score improvements up to 97–100, created new testing pipelines, and led teams
               building customer-facing platforms at scale.
             </p>
@@ -39,31 +39,31 @@ import WorkingTogether from '../components/WorkingTogether.html'
     </section>
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
-      <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)] lg:grid-cols-[240px,1fr]">
+      <div class="grid gap-8 items-start rounded-[2.5rem] border border-white/70 bg-white/85 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)] lg:grid-cols-[240px,1fr]">
         <div class="space-y-2">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Featured</p>
-          <h2 class="text-3xl font-semibold text-[#0c111f]">Developer Tooling</h2>
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Featured</p>
+          <h2 class="text-3xl font-semibold text-[#2f3447]">Developer Tooling</h2>
         </div>
         <div class="space-y-6">
-          <div class="rounded-2xl border border-white/70 bg-white/80 p-6">
-            <h3 class="font-semibold text-xl text-[#0c111f]">Next-gen HMR + React Fast Refresh</h3>
-            <p class="mt-3 text-[#4a5162]">
+          <div class="rounded-2xl border border-white/70 bg-white/90 p-6">
+            <h3 class="font-semibold text-xl text-[#2f3447]">Next-gen HMR + React Fast Refresh</h3>
+            <p class="mt-3 text-[#5f6577]">
               Building a workflow that lets developers focus on specific components and iterate without losing state
               or context. The goal is a seamless, fluid development experience that removes delays and distractions.
             </p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
-            <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
-              <p class="font-semibold text-[#0c111f]">Key Outcomes</p>
-              <ul class="mt-2 list-disc list-inside space-y-1 text-[#4a5162]">
+            <div class="rounded-2xl border border-white/70 bg-white/90 p-5">
+              <p class="font-semibold text-[#2f3447]">Key Outcomes</p>
+              <ul class="mt-2 list-disc list-inside space-y-1 text-[#5f6577]">
                 <li>Component-focused previews</li>
                 <li>State-preserving hot reload</li>
                 <li>Immediate feedback loops</li>
               </ul>
             </div>
-            <div class="rounded-2xl border border-white/70 bg-white/80 p-5">
-              <p class="font-semibold text-[#0c111f]">Status</p>
-              <p class="mt-2 text-[#4a5162]">
+            <div class="rounded-2xl border border-white/70 bg-white/90 p-5">
+              <p class="font-semibold text-[#2f3447]">Status</p>
+              <p class="mt-2 text-[#5f6577]">
                 Actively prototyping and validating workflows with modern web stacks.
               </p>
             </div>
@@ -74,19 +74,19 @@ import WorkingTogether from '../components/WorkingTogether.html'
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-6 md:grid-cols-2">
-        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">BMW Group</p>
-          <h2 class="mt-3 text-2xl font-semibold text-[#0c111f]">Smart Mobility Platforms</h2>
-          <ul class="mt-4 list-disc list-inside space-y-2 text-[#4a5162]">
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/85 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">BMW Group</p>
+          <h2 class="mt-3 text-2xl font-semibold text-[#2f3447]">Smart Mobility Platforms</h2>
+          <ul class="mt-4 list-disc list-inside space-y-2 text-[#5f6577]">
             <li>Led Gatsby + React marketing site from scratch.</li>
             <li>Improved Lighthouse performance from 45% to 97% and accessibility to 100%.</li>
             <li>Delivered Angular 10 smart charging and Angular 12 + NestJS smart ticket platform.</li>
           </ul>
         </div>
-        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-8 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#2662ff]">Engineering Leadership</p>
-          <h2 class="mt-3 text-2xl font-semibold text-[#0c111f]">Testing & Delivery</h2>
-          <ul class="mt-4 list-disc list-inside space-y-2 text-[#4a5162]">
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/85 p-8 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-[#e8895e]">Engineering Leadership</p>
+          <h2 class="mt-3 text-2xl font-semibold text-[#2f3447]">Testing & Delivery</h2>
+          <ul class="mt-4 list-disc list-inside space-y-2 text-[#5f6577]">
             <li>Built TypeScript testing pipeline with TestCafe, Jenkins, and Jira reporting.</li>
             <li>Mentored and coached teams through design and code review cycles.</li>
             <li>Improved performance for enterprise platforms across global clients.</li>
@@ -97,17 +97,17 @@ import WorkingTogether from '../components/WorkingTogether.html'
 
     <section class="w-full mx-auto px-[1.5rem] max-w-[83rem]">
       <div class="grid gap-6 md:grid-cols-3">
-        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
-          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Industries</p>
-          <p class="mt-4 text-[#4a5162]">Automotive, healthcare, retail, developer tooling, and smart mobility.</p>
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/85 p-6 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#a3988f]">Industries</p>
+          <p class="mt-4 text-[#5f6577]">Automotive, healthcare, retail, developer tooling, and smart mobility.</p>
         </div>
-        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
-          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Strengths</p>
-          <p class="mt-4 text-[#4a5162]">Performance optimization, accessibility excellence, and scalable frontend architecture.</p>
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/85 p-6 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#a3988f]">Strengths</p>
+          <p class="mt-4 text-[#5f6577]">Performance optimization, accessibility excellence, and scalable frontend architecture.</p>
         </div>
-        <div class="rounded-[2.5rem] border border-white/70 bg-white/75 p-6 shadow-[0_25px_60px_rgba(15,23,42,0.08)]">
-          <p class="text-sm uppercase tracking-[0.25em] text-[#8b93a7]">Location</p>
-          <p class="mt-4 text-[#4a5162]">Based in Valencia, Spain with 7 years of US experience.</p>
+        <div class="rounded-[2.5rem] border border-white/70 bg-white/85 p-6 shadow-[0_25px_60px_rgba(45,42,36,0.08)]">
+          <p class="text-sm uppercase tracking-[0.25em] text-[#a3988f]">Location</p>
+          <p class="mt-4 text-[#5f6577]">Based in Valencia, Spain with 7 years of US experience.</p>
         </div>
       </div>
     </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,3 +2,17 @@
 details > summary::-webkit-details-marker {
   display: none;
 }
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  font-family: 'Manrope', 'Inter', 'SF Pro Display', system-ui, sans-serif;
+  letter-spacing: -0.01em;
+}
+
+::selection {
+  background: rgba(47, 107, 255, 0.2);
+  color: #0b0f1a;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,10 +9,10 @@ details > summary::-webkit-details-marker {
 
 body {
   font-family: 'Manrope', 'Inter', 'SF Pro Display', system-ui, sans-serif;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
 }
 
 ::selection {
-  background: rgba(47, 107, 255, 0.2);
-  color: #0b0f1a;
+  background: rgba(38, 98, 255, 0.2);
+  color: #0c111f;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,10 +9,10 @@ details > summary::-webkit-details-marker {
 
 body {
   font-family: 'Manrope', 'Inter', 'SF Pro Display', system-ui, sans-serif;
-  letter-spacing: -0.015em;
+  letter-spacing: -0.01em;
 }
 
 ::selection {
-  background: rgba(38, 98, 255, 0.2);
-  color: #0c111f;
+  background: rgba(242, 149, 98, 0.25);
+  color: #2f3447;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,3 +16,38 @@ body {
   background: rgba(242, 149, 98, 0.25);
   color: #2f3447;
 }
+
+@keyframes floatSlow {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -18px, 0);
+  }
+}
+
+@keyframes floatFast {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(8px, -14px, 0);
+  }
+}
+
+.animate-float-slow {
+  animation: floatSlow 7s ease-in-out infinite;
+}
+
+.animate-float-fast {
+  animation: floatFast 5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-float-slow,
+  .animate-float-fast {
+    animation: none;
+  }
+}


### PR DESCRIPTION
### Motivation

- Modernize the personal site content and layout for 2026 with a clear, production-ready `Work` section and updated `About` content.  
- Surface a developer-experience focus (next-gen HMR / React Fast Refresh) and replace placeholder "WIP" navigation entries with real links.  

### Description

- Added a new `src/pages/work.astro` page that highlights specialties, featured tooling work, key outcomes, and select project highlights.  
- Rewrote `src/components/AboutHero.html` copy to reflect a 10+ year experience summary and updated the hero messaging.  
- Replaced the previous `AboutMain` blocks with a refreshed `src/components/AboutMain.html` that presents current focus, career timeline, and recognition/languages.  
- Updated `src/components/Nav.html` to remove "WIP" labels and wire navigation to `/work` and `/about`.  

### Testing

- Started the dev server with `npm run dev` and confirmed Astro served the site successfully.  
- Ran an automated Playwright script that navigated to `http://127.0.0.1:4321/work` and captured a screenshot (`artifacts/work-page.png`), which completed successfully.  
- Verified files were staged and committed; the local commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5ba61d1883239260aaffe23d6d36)